### PR TITLE
Fix "Error: Package suggested but not available: 'lixoftConnectors'"

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,10 @@ on:
 
 name: R-CMD-check
 
+# Fix "Error: Package suggested but not available: 'lixoftConnectors'"
+env:
+  _R_CHECK_FORCE_SUGGESTS_: false
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
I believe that this will fix the error "Error: Package suggested but not available: 'lixoftConnectors'"

It appears that you have to have a copy of Monolix available to install the package (https://monolix.lixoft.com/monolix-api/lixoftconnectors_installation/), and I don't think that's likely to be achievable in the CI environment.