### PR TITLE
Skip tests when other estimators cannot be run

### DIFF
--- a/tests/testthat/test-monolix-read.R
+++ b/tests/testthat/test-monolix-read.R
@@ -1,4 +1,5 @@
 test_that("test monolix reading for 2019, 2020, and 2021", {
+  skip_if_not_installed("lixoftConnectors")
 
   pk.turnover.emax3 <- function() {
     ini({
@@ -84,6 +85,7 @@ test_that("test monolix reading for 2019, 2020, and 2021", {
 
 
 test_that("test more nlmixr2/monolix features", {
+  skip_if_not_installed("lixoftConnectors")
 
   pk.turnover.emax4 <- function() {
     ini({
@@ -151,6 +153,7 @@ test_that("test more nlmixr2/monolix features", {
 
 
 test_that("test pheno", {
+  skip_if_not_installed("lixoftConnectors")
 
   pheno <- function() {
     ini({
@@ -184,6 +187,7 @@ test_that("test pheno", {
 })
 
 test_that("pbpk mavoglurant", {
+  skip_if_not_installed("lixoftConnectors")
 
   pbpk <- function(){
     ini({
@@ -298,6 +302,7 @@ test_that("pbpk mavoglurant", {
 })
 
 test_that("nimo test", {
+  skip_if_not_installed("lixoftConnectors")
 
   nimo <- function() {
     ini({
@@ -361,6 +366,7 @@ test_that("nimo test", {
 })
 
 test_that("wbc", {
+  skip_if_not_installed("lixoftConnectors")
 
   wbc <- function() {
     ini({
@@ -467,6 +473,4 @@ test_that("wbc", {
       expect_true(inherits(p2, "nlmixr2FitData"))
     })
   }
-
-
 })

--- a/tests/testthat/test-nonmem-read.R
+++ b/tests/testthat/test-nonmem-read.R
@@ -1,4 +1,9 @@
 test_that("warfarin NONMEM reading", {
+  # Skip if NONMEM cannot be run
+  skip_if(
+    getOption("babelmixr2.nonmem", "") == "",
+    message="NONMEM is not setup to be run"
+  )
 
   pk.turnover.emax3 <- function() {
     ini({
@@ -96,6 +101,11 @@ test_that("warfarin NONMEM reading", {
 })
 
 test_that("pheno NONMEM reading", {
+  # Skip if NONMEM cannot be run
+  skip_if(
+    getOption("babelmixr2.nonmem", "") == "",
+    message="NONMEM is not setup to be run"
+  )
 
   pheno <- function() {
     ini({
@@ -129,6 +139,11 @@ test_that("pheno NONMEM reading", {
 })
 
 test_that("wbc NONMEM reading", {
+  # Skip if NONMEM cannot be run
+  skip_if(
+    getOption("babelmixr2.nonmem", "") == "",
+    message="NONMEM is not setup to be run"
+  )
 
   wbc <- function() {
     ini({


### PR DESCRIPTION
This will skip the NONMEM and Monolix tests when they cannot be run.