### PR TITLE
Clarify skipped tests by filename

### DIFF
--- a/tests/testthat/test-monolix-read.R
+++ b/tests/testthat/test-monolix-read.R
@@ -1,58 +1,57 @@
+pk.turnover.emax3 <- function() {
+  ini({
+    tktr <- log(1)
+    tka <- log(1)
+    tcl <- log(0.1)
+    tv <- log(10)
+    ##
+    eta.ktr ~ 1
+    eta.ka ~ 1
+    eta.cl ~ 2
+    eta.v ~ 1
+    prop.err <- 0.1
+    pkadd.err <- 0.1
+    ##
+    temax <- logit(0.8)
+    tec50 <- log(0.5)
+    tkout <- log(0.05)
+    te0 <- log(100)
+    ##
+    eta.emax ~ .5
+    eta.ec50  ~ .5
+    eta.kout ~ .5
+    eta.e0 ~ .5
+    ##
+    pdadd.err <- 10
+  })
+  model({
+    ktr <- exp(tktr + eta.ktr)
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v <- exp(tv + eta.v)
+    emax = expit(temax+eta.emax)
+    ec50 =  exp(tec50 + eta.ec50)
+    kout = exp(tkout + eta.kout)
+    e0 = exp(te0 + eta.e0)
+    ##
+    DCP = center/v
+    PD=1-emax*DCP/(ec50+DCP)
+    ##
+    effect(0) = e0
+    kin = e0*kout
+    ##
+    d/dt(depot) = -ktr * depot
+    d/dt(gut) =  ktr * depot -ka * gut
+    d/dt(center) =  ka * gut - cl / v * center
+    d/dt(effect) = kin*PD -kout*effect
+    ##
+    cp = center / v
+    cp ~ prop(prop.err) + add(pkadd.err)
+    effect ~ add(pdadd.err) | pca
+  })
+}
+
 test_that("test monolix reading for 2019, 2020, and 2021", {
-
-  pk.turnover.emax3 <- function() {
-    ini({
-      tktr <- log(1)
-      tka <- log(1)
-      tcl <- log(0.1)
-      tv <- log(10)
-      ##
-      eta.ktr ~ 1
-      eta.ka ~ 1
-      eta.cl ~ 2
-      eta.v ~ 1
-      prop.err <- 0.1
-      pkadd.err <- 0.1
-      ##
-      temax <- logit(0.8)
-      tec50 <- log(0.5)
-      tkout <- log(0.05)
-      te0 <- log(100)
-      ##
-      eta.emax ~ .5
-      eta.ec50  ~ .5
-      eta.kout ~ .5
-      eta.e0 ~ .5
-      ##
-      pdadd.err <- 10
-    })
-    model({
-      ktr <- exp(tktr + eta.ktr)
-      ka <- exp(tka + eta.ka)
-      cl <- exp(tcl + eta.cl)
-      v <- exp(tv + eta.v)
-      emax = expit(temax+eta.emax)
-      ec50 =  exp(tec50 + eta.ec50)
-      kout = exp(tkout + eta.kout)
-      e0 = exp(te0 + eta.e0)
-      ##
-      DCP = center/v
-      PD=1-emax*DCP/(ec50+DCP)
-      ##
-      effect(0) = e0
-      kin = e0*kout
-      ##
-      d/dt(depot) = -ktr * depot
-      d/dt(gut) =  ktr * depot -ka * gut
-      d/dt(center) =  ka * gut - cl / v * center
-      d/dt(effect) = kin*PD -kout*effect
-      ##
-      cp = center / v
-      cp ~ prop(prop.err) + add(pkadd.err)
-      effect ~ add(pdadd.err) | pca
-    })
-  }
-
   if (file.exists("pk.turnover.emax3-2019.zip")) {
     .path <- normalizePath("pk.turnover.emax3-2019.zip")
     withr::with_tempdir({
@@ -79,7 +78,6 @@ test_that("test monolix reading for 2019, 2020, and 2021", {
       expect_true(inherits(f, "nlmixr2FitData"))
     })
   }
-
 })
 
 
@@ -139,18 +137,16 @@ test_that("test more nlmixr2/monolix features", {
   }
 
 
-  if (file.exists("pk.turnover.emax4-2021.zip")) {
-    .path <- normalizePath("pk.turnover.emax4-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      f <- nlmixr2::nlmixr(pk.turnover.emax4, nlmixr2data::warfarin, "monolix")
-      expect_true(inherits(f, "nlmixr2FitData"))
-    })
-  }
+  skip_if_not(file.exists("pk.turnover.emax4-2021.zip"))
+  .path <- normalizePath("pk.turnover.emax4-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    f <- nlmixr2::nlmixr(pk.turnover.emax4, nlmixr2data::warfarin, "monolix")
+    expect_true(inherits(f, "nlmixr2FitData"))
+  })
 })
 
-
-test_that("test pheno", {
+test_that("test Monolix pheno", {
 
   pheno <- function() {
     ini({
@@ -173,14 +169,13 @@ test_that("test pheno", {
   }
 
 
-  if (file.exists("pheno-2021.zip")) {
-    .path <- normalizePath("pheno-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      f <- nlmixr2::nlmixr(pheno, nlmixr2data::pheno_sd, "monolix")
-      expect_true(inherits(f, "nlmixr2FitData"))
-    })
-  }
+  skip_if_not(file.exists("pheno-2021.zip"))
+  .path <- normalizePath("pheno-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    f <- nlmixr2::nlmixr(pheno, nlmixr2data::pheno_sd, "monolix")
+    expect_true(inherits(f, "nlmixr2FitData"))
+  })
 })
 
 test_that("pbpk mavoglurant", {
@@ -286,19 +281,16 @@ test_that("pbpk mavoglurant", {
 
   expect_error(bblDatToMonolix(pbpk, nlmixr2data::mavoglurant), NA)
 
-  if (file.exists("pbpk-2021.zip")) {
-    .path <- normalizePath("pbpk-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      f <- nlmixr2::nlmixr(pbpk, nlmixr2data::mavoglurant, "monolix")
-      expect_true(inherits(f, "nlmixr2FitData"))
-    })
-  }
-
+  skip_if_not(file.exists("pbpk-2021.zip"))
+  .path <- normalizePath("pbpk-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    f <- nlmixr2::nlmixr(pbpk, nlmixr2data::mavoglurant, "monolix")
+    expect_true(inherits(f, "nlmixr2FitData"))
+  })
 })
 
 test_that("nimo test", {
-
   nimo <- function() {
     ini({
       ## Note that the UI can take expressions
@@ -350,123 +342,121 @@ test_that("nimo test", {
 
   tmp$DV <-exp(tmp$DV)
 
-  if (file.exists("nimo-2021.zip")) {
-    .path <- normalizePath("nimo-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      f <- suppressWarnings(nlmixr2::nlmixr2(nimo, tmp, "monolix"))
-      expect_true(inherits(f, "nlmixr2FitData"))
-    })
-  }
+  skip_if_not(file.exists("nimo-2021.zip"))
+  .path <- normalizePath("nimo-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    f <- suppressWarnings(nlmixr2::nlmixr2(nimo, tmp, "monolix"))
+    expect_true(inherits(f, "nlmixr2FitData"))
+  })
 })
 
-test_that("wbc", {
+# WBC Model tests ####
 
-  wbc <- function() {
-    ini({
-      ## Note that the UI can take expressions
-      ## Also note that these initial estimates should be provided on the log-scale
-      log_CIRC0 <- log(7.21)
-      log_MTT <- log(124)
-      log_SLOPU <- log(28.9)
-      log_GAMMA <- log(0.239)
-      ## Initial estimates should be high for SAEM ETAs
-      eta.CIRC0  ~ .1
-      eta.MTT  ~ .03
-      eta.SLOPU ~ .2
-      ##  Also true for additive error (also ignored in SAEM)
-      prop.err <- 10
-    })
-    model({
-      CIRC0 =  exp(log_CIRC0 + eta.CIRC0)
-      MTT =  exp(log_MTT + eta.MTT)
-      SLOPU =  exp(log_SLOPU + eta.SLOPU)
-      GAMMA = exp(log_GAMMA)
+wbc <- function() {
+  ini({
+    ## Note that the UI can take expressions
+    ## Also note that these initial estimates should be provided on the log-scale
+    log_CIRC0 <- log(7.21)
+    log_MTT <- log(124)
+    log_SLOPU <- log(28.9)
+    log_GAMMA <- log(0.239)
+    ## Initial estimates should be high for SAEM ETAs
+    eta.CIRC0  ~ .1
+    eta.MTT  ~ .03
+    eta.SLOPU ~ .2
+    ##  Also true for additive error (also ignored in SAEM)
+    prop.err <- 10
+  })
+  model({
+    CIRC0 =  exp(log_CIRC0 + eta.CIRC0)
+    MTT =  exp(log_MTT + eta.MTT)
+    SLOPU =  exp(log_SLOPU + eta.SLOPU)
+    GAMMA = exp(log_GAMMA)
+    
+    # PK parameters from input dataset
+    CL = CLI;
+    V1 = V1I;
+    V2 = V2I;
+    Q = 204;
+    
+    CONC = A_centr/V1;
+    
+    # PD parameters
+    NN = 3;
+    KTR = (NN + 1)/MTT;
+    EDRUG = 1 - SLOPU * CONC;
+    FDBK = (CIRC0 / A_circ)^GAMMA;
+    
+    CIRC = A_circ;
+    
+    A_prol(0) = CIRC0;
+    A_tr1(0) = CIRC0;
+    A_tr2(0) = CIRC0;
+    A_tr3(0) = CIRC0;
+    A_circ(0) = CIRC0;
+    
+    d/dt(A_centr) = A_periph * Q/V2 - A_centr * (CL/V1 + Q/V1);
+    d/dt(A_periph) = A_centr * Q/V1 - A_periph * Q/V2;
+    d/dt(A_prol) = KTR * A_prol * EDRUG * FDBK - KTR * A_prol;
+    d/dt(A_tr1) = KTR * A_prol - KTR * A_tr1;
+    d/dt(A_tr2) = KTR * A_tr1 - KTR * A_tr2;
+    d/dt(A_tr3) = KTR * A_tr2 - KTR * A_tr3;
+    d/dt(A_circ) = KTR * A_tr3 - KTR * A_circ;
+    
+    CIRC ~ prop(prop.err)
+  })
+}
 
-      # PK parameters from input dataset
-      CL = CLI;
-      V1 = V1I;
-      V2 = V2I;
-      Q = 204;
+test_that("Monolix wbc", {
+  skip_if_not(file.exists("wbc-2021.zip"))
+  skip_if_not(file.exists("wbc-charts-2021.zip"))
+  .path <- normalizePath("wbc-2021.zip")
+  .pathCharts <- normalizePath("wbc-charts-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    
+    f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
+    expect_true(inherits(f, "nlmixr2FitData"))
+    expect_equal(f$env$parHist, NULL)
+    
+    unzip(.pathCharts)
+    
+    f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
+    expect_true(inherits(f, "nlmixr2FitData"))
+    expect_true(inherits(f$env$parHist, "data.frame"))
+    
+    f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
+    expect_true(inherits(f, "nlmixr2FitData"))
+    expect_true(inherits(f$env$parHist, "data.frame"))
+    
+  })
+  
+  withr::with_tempdir({
+    unzip(.path)
+    unzip(.pathCharts)
+    f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
+    expect_true(inherits(f, "nlmixr2FitData"))
+    expect_true(inherits(f$env$parHist, "data.frame"))
+  })
+})
 
-      CONC = A_centr/V1;
-
-      # PD parameters
-      NN = 3;
-      KTR = (NN + 1)/MTT;
-      EDRUG = 1 - SLOPU * CONC;
-      FDBK = (CIRC0 / A_circ)^GAMMA;
-
-      CIRC = A_circ;
-
-      A_prol(0) = CIRC0;
-      A_tr1(0) = CIRC0;
-      A_tr2(0) = CIRC0;
-      A_tr3(0) = CIRC0;
-      A_circ(0) = CIRC0;
-
-      d/dt(A_centr) = A_periph * Q/V2 - A_centr * (CL/V1 + Q/V1);
-      d/dt(A_periph) = A_centr * Q/V1 - A_periph * Q/V2;
-      d/dt(A_prol) = KTR * A_prol * EDRUG * FDBK - KTR * A_prol;
-      d/dt(A_tr1) = KTR * A_prol - KTR * A_tr1;
-      d/dt(A_tr2) = KTR * A_tr1 - KTR * A_tr2;
-      d/dt(A_tr3) = KTR * A_tr2 - KTR * A_tr3;
-      d/dt(A_circ) = KTR * A_tr3 - KTR * A_circ;
-
-      CIRC ~ prop(prop.err)
-    })
-  }
-
-  if (file.exists("wbc-2021.zip")) {
-    .path <- normalizePath("wbc-2021.zip")
-    .pathCharts <- normalizePath("wbc-charts-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-
-      f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
-      expect_true(inherits(f, "nlmixr2FitData"))
-      expect_equal(f$env$parHist, NULL)
-
-      unzip(.pathCharts)
-
-      f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
-      expect_true(inherits(f, "nlmixr2FitData"))
-      expect_true(inherits(f$env$parHist, "data.frame"))
-
-      f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
-      expect_true(inherits(f, "nlmixr2FitData"))
-      expect_true(inherits(f$env$parHist, "data.frame"))
-
-    })
-
-    withr::with_tempdir({
-      unzip(.path)
-      unzip(.pathCharts)
-      f <- suppressWarnings(nlmixr2::nlmixr2(wbc, nlmixr2data::wbcSim, "monolix"))
-      expect_true(inherits(f, "nlmixr2FitData"))
-      expect_true(inherits(f$env$parHist, "data.frame"))
-    })
-  }
-
-  if (file.exists("x-2021.zip")) {
-
-    .path <- normalizePath("x-2021.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      # with piping, the original model name is scrubbed, and is changed to x
-      p1 <- wbc %>%
-        ini(prop.err=15) %>%
-        nlmixr2(., nlmixr2data::wbcSim, "monolix")
-
-      expect_true(inherits(p1, "nlmixr2FitData"))
-
-      p2 <-wbc %>%
-        ini(prop.err=7) %>%
-        nlmixr2(., nlmixr2data::wbcSim, "monolix")
-
-      expect_true(inherits(p2, "nlmixr2FitData"))
-    })
-  }
-
-
+test_that("Monolix wbc test 2", {
+  skip_if_not(file.exists("x-2021.zip"))
+  .path <- normalizePath("x-2021.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    # with piping, the original model name is scrubbed, and is changed to x
+    p1 <- wbc %>%
+      ini(prop.err=15) %>%
+      nlmixr2(., nlmixr2data::wbcSim, "monolix")
+    
+    expect_true(inherits(p1, "nlmixr2FitData"))
+    
+    p2 <-wbc %>%
+      ini(prop.err=7) %>%
+      nlmixr2(., nlmixr2data::wbcSim, "monolix")
+    
+    expect_true(inherits(p2, "nlmixr2FitData"))
+  })
 })

--- a/tests/testthat/test-nonmem-read.R
+++ b/tests/testthat/test-nonmem-read.R
@@ -53,46 +53,45 @@ test_that("warfarin NONMEM reading", {
     })
   }
 
-  if (file.exists("pk.turnover.emax3.zip")) {
-    .path <- normalizePath("pk.turnover.emax3.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      # This has rounding errors
-      expect_error(nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
-                                   nonmemControl(readRounding=FALSE)))
-
-      # Can still load the model to get information (possibly pipe) and create a new model
-      f <- nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
-                  nonmemControl(readRounding=TRUE))
-
-      expect_true(inherits(f, "nlmixr2FitData"))
-
-      # Will still error if you try to read this with readRounding=FALSE
-      expect_error(nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
-                          nonmemControl(readRounding=FALSE)))
-
-      # Note this shouldn't have a covariance step so you can add it (at least a nlmixr2 covariance step)
-      getVarCov(f)
-
-      # nlmixr2 is more generous in what constitutes a covariance
-      # step, in this case it is |r|,|s| which should be regarded with
-      # caution but can give some clues on why this is not working in
-      # NONMEM.
-
-      # Here you can see the shrinkage is high for temax tktr and tka,
-      # so they could be dropped with a model in nonmem that is more
-      # likely to converge in NONMEM, starting from the model
-
-      # In addition to dropping the problematic parameters, this will
-      # restart the fit at the final initial estimates
-
-      f %>% model(ktr <- exp(tktr)) %>%
-        model(ka <- exp(tka)) %>%
-        model(kout <- exp(tkout + eta.kout)) %>%
-        nlmixr(data=nlmixr2data::warfarin, est="nonmem", control=nonmemControl(readRounding=FALSE))
-
-    })
-  }
+  skip_if_not(file.exists("pk.turnover.emax3.zip"))
+  .path <- normalizePath("pk.turnover.emax3.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    # This has rounding errors
+    expect_error(nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
+                        nonmemControl(readRounding=FALSE)))
+    
+    # Can still load the model to get information (possibly pipe) and create a new model
+    f <- nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
+                nonmemControl(readRounding=TRUE))
+    
+    expect_true(inherits(f, "nlmixr2FitData"))
+    
+    # Will still error if you try to read this with readRounding=FALSE
+    expect_error(nlmixr(pk.turnover.emax3, nlmixr2data::warfarin, "nonmem",
+                        nonmemControl(readRounding=FALSE)))
+    
+    # Note this shouldn't have a covariance step so you can add it (at least a nlmixr2 covariance step)
+    getVarCov(f)
+    
+    # nlmixr2 is more generous in what constitutes a covariance
+    # step, in this case it is |r|,|s| which should be regarded with
+    # caution but can give some clues on why this is not working in
+    # NONMEM.
+    
+    # Here you can see the shrinkage is high for temax tktr and tka,
+    # so they could be dropped with a model in nonmem that is more
+    # likely to converge in NONMEM, starting from the model
+    
+    # In addition to dropping the problematic parameters, this will
+    # restart the fit at the final initial estimates
+    
+    f %>% model(ktr <- exp(tktr)) %>%
+      model(ka <- exp(tka)) %>%
+      model(kout <- exp(tkout + eta.kout)) %>%
+      nlmixr(data=nlmixr2data::warfarin, est="nonmem", control=nonmemControl(readRounding=FALSE))
+    
+  })
 })
 
 test_that("pheno NONMEM reading", {
@@ -117,15 +116,13 @@ test_that("pheno NONMEM reading", {
     })
   }
 
-  if (file.exists("pheno.zip")) {
-    .path <- normalizePath("pheno.zip")
-    withr::with_tempdir({
-      unzip(.path)
-      f <- nlmixr2::nlmixr(pheno, nlmixr2data::pheno_sd, "nonmem")
-      expect_true(inherits(f, "nlmixr2FitData"))
-    })
-  }
-
+  skip_if_not(file.exists("pheno.zip"))
+  .path <- normalizePath("pheno.zip")
+  withr::with_tempdir({
+    unzip(.path)
+    f <- nlmixr2::nlmixr(pheno, nlmixr2data::pheno_sd, "nonmem")
+    expect_true(inherits(f, "nlmixr2FitData"))
+  })
 })
 
 test_that("wbc NONMEM reading", {
@@ -185,11 +182,10 @@ test_that("wbc NONMEM reading", {
     })
   }
 
+  skip_if_not(file.exists("wbc.zip"))
   .path <- normalizePath("wbc.zip")
   withr::with_tempdir({
       unzip(.path)
       f <- nlmixr2(wbc, nlmixr2data::wbcSim, "nonmem")
   })
-
-
 })


### PR DESCRIPTION
This PR splits out tests more granularly so that they show clearer skipped tests when they are skipped due to missing files.