### PR TITLE
Stop when non-interactive and no run command

### DIFF
--- a/R/monolixNlmixr2est.R
+++ b/R/monolixNlmixr2est.R
@@ -239,6 +239,9 @@
         lixoftConnectors::runScenario()
         .minfo("done")
         .runLS <- TRUE
+      } else if (!interactive()) {
+        # Don't wait when running in a script or test
+        stop("setup monolix's run command")
       } else {
         .minfo("run monolix manually or stop and setup monolix's run command")
       }

--- a/R/nonmemNlmixr2est.R
+++ b/R/nonmemNlmixr2est.R
@@ -207,6 +207,9 @@
       .minfo(paste0("run NONMEM: ", sprintf(.cmd, .arg)))
       withr::with_dir(.exportPath,
                       system(sprintf(.cmd, .arg)))
+    } else if (!interactive()) {
+      # Don't wait when running in a script or test
+      stop("setup NONMEM's run command")
     } else {
       .minfo("run NONMEM manually or setup NONMEM's run command")
     }


### PR DESCRIPTION
When running non-interactively (like in scripts or tests), this will raise an error instead of waiting for the user to run the command.