### PR TITLE
Support NONMEM run functions

### DIFF
--- a/R/nonmemNlmixr2est.R
+++ b/R/nonmemNlmixr2est.R
@@ -200,18 +200,14 @@
               quote=FALSE)
     .minfo("done")
   }
-  .cmd <- rxode2::rxGetControl(.ui, "runCommand", "")
   if (!file.exists(file.path(.exportPath, .ui$nonmemXml))) {
-    if (.cmd != "") {
-      .arg <- paste0(.ui$nonmemNmctl, " ", .ui$nonmemNmlst)
-      .minfo(paste0("run NONMEM: ", sprintf(.cmd, .arg)))
-      withr::with_dir(.exportPath,
-                      system(sprintf(.cmd, .arg)))
-    } else if (!interactive()) {
-      # Don't wait when running in a script or test
-      stop("setup NONMEM's run command")
+    .cmd <- rxode2::rxGetControl(.ui, "runCommand", "")
+    if (is.character(.cmd)) {
+      .nonmemRunCommand(ui=.ui, cmd=.cmd)
+    } else if (is.function(.cmd)) {
+      .cmd(ui=.ui)
     } else {
-      .minfo("run NONMEM manually or setup NONMEM's run command")
+      stop("invalid value for nonmemControl(runCommand=)")
     }
   }
   if (!file.exists(file.path(.exportPath, .ui$nonmemXml))) {
@@ -277,6 +273,20 @@
     qs::qsave(.ret, .qs)
   }
   return(.ret)
+}
+
+.nonmemRunCommand <- function(ui, cmd) {
+  if (cmd != "") {
+    .arg <- paste0(ui$nonmemNmctl, " ", ui$nonmemNmlst)
+    .minfo(paste0("run NONMEM: ", sprintf(cmd, .arg)))
+    withr::with_dir(ui$nonmemExportPath,
+                    system(sprintf(cmd, .arg)))
+  } else if (!interactive()) {
+    # Don't wait when running in a script or test
+    stop("setup NONMEM's run command")
+  } else {
+    .minfo("run NONMEM manually or setup NONMEM's run command")
+  }
 }
 
 #' @export

--- a/man/nonmemControl.Rd
+++ b/man/nonmemControl.Rd
@@ -64,8 +64,8 @@ nonmemControl(
 \item{outputExtension}{Extension to use for the NONMEM output
 listing}
 
-\item{runCommand}{Command to run NONMEM (typically the path to
-"nmfe75")}
+\item{runCommand}{Command to run NONMEM (typically the path to "nmfe75") or a
+function with an argument \code{ui}.  See the details for more information.}
 
 \item{iniSigDig}{How many significant digits are printed in $THETA
 and $OMEGA when the estimate is zero.  Also controls the zero
@@ -97,6 +97,26 @@ babelmixr2 control option for generating NONMEM control stream and
 }
 \description{
 NONMEM estimation control
+}
+\details{
+If \code{runCommand} is given as a string, it will be called with the
+\code{system()} command like:
+
+\code{runCommand controlFile outputFile}.
+
+For example, if \code{runCommand="'/path/to/nmfe75'"} then the command line
+used would look like the following:
+
+\code{'/path/to/nmfe75' one.cmt.nmctl one.cmt.lst}
+
+If \code{runCommand} is given as a function, it will be called as
+\code{FUN(ui)} to run NONMEM.  This allows you to run NONMEM in any way that
+you may need, as long as you can write it in R.  You will need to run NONMEM
+where the files are in the \code{ui$nonmemExportPath} directory, the control
+stream is in \code{ui$nonmemNmctl}, and all outputs must be placed in the
+same directory when the run is complete.  babelmixr2 will wait for the NONMEM
+XML output file (\code{ui$nonmemXml}) to exist in the directory before
+proceeding.
 }
 \examples{
 nonmemControl()


### PR DESCRIPTION
fix #23

This is a draft to try to allow functions to call NONMEM.

While working on this, I've created a state that is equivalent to a completely-failed run (no outputs other than the .xml file which has no data).  I've worked through many of the underlying issues, but there is an error when I run the draft of a new test case:

```
Error in chol.default(mat2) : 
  the leading minor of order 1 is not positive definite
Error : initial 'omega' matrix inverse is non-positive definite
Error: initial 'omega' matrix inverse is non-positive definite
```

The reason is because I created an all-`NA` matrix to pretend to be the outputs.  (That seemed to be the best path.  Maybe it's not.)

@mattfidler, any ideas of how to fix that?