### PR TITLE
Allow functions to run NONMEM in addition to a command line character string; allow not running NONMEM; test full models

### DIFF
--- a/R/nonmemControl.R
+++ b/R/nonmemControl.R
@@ -1,4 +1,24 @@
 #' NONMEM estimation control
+#' 
+#' @details
+#' 
+#' If \code{runCommand} is given as a string, it will be called with the
+#' \code{system()} command like:
+#' 
+#' \code{runCommand controlFile outputFile}.
+#' 
+#' For example, if \code{runCommand="'/path/to/nmfe75'"} then the command line
+#' used would look like the following:
+#' 
+#' \code{'/path/to/nmfe75' one.cmt.nmctl one.cmt.lst}
+#' 
+#' If \code{runCommand} is given as a function, it will be called as
+#' \code{FUN(ctl, directory, ui)} to run NONMEM.  This allows you to run NONMEM
+#' in any way that you may need, as long as you can write it in R.  babelmixr2
+#' will wait for the function to return before proceeding.
+#' 
+#' If \code{runCommand} is \code{NA}, \code{nlmixr()} will stop after writing
+#' the model files and without starting NONMEM.
 #'
 #' @param est NONMEM estimation method
 #' @param advanOde The ODE solving method for NONMEM
@@ -11,8 +31,8 @@
 #' @param extension NONMEM file extensions
 #' @param outputExtension Extension to use for the NONMEM output
 #'   listing
-#' @param runCommand Command to run NONMEM (typically the path to
-#'   "nmfe75")
+#' @param runCommand Command to run NONMEM (typically the path to "nmfe75") or a
+#'   function.  See the details for more information.
 #' @param iniSigDig How many significant digits are printed in $THETA
 #'   and $OMEGA when the estimate is zero.  Also controls the zero
 #'   protection numbers
@@ -110,8 +130,13 @@ nonmemControl <- function(est=c("focei", "imp", "its", "posthoc"),
   if (!is.null(modelName)) {
     checkmate::assertCharacter(modelName, len=1, any.missing=FALSE)
   }
-  if (runCommand != "") checkmate::assertCharacter(runCommand, pattern="%s", min.len=1, max.len=1)
-    .xtra <- list(...)
+  if (!identical(runCommand, "")) {
+    if (!(checkmate::testCharacter(runCommand, pattern="%s", min.len=1, max.len=1) |
+          checkmate::testFunction(runCommand, args=c("ctl", "directory", "ui")))) {
+      stop("runCommand must be a character string or a function with arguments 'ctl', 'directory', and 'ui'")
+    }
+  }
+  .xtra <- list(...)
   .bad <- names(.xtra)
   .bad <- .bad[!(.bad %in% c("genRxControl"))]
   if (length(.bad) > 0) {

--- a/man/nonmemControl.Rd
+++ b/man/nonmemControl.Rd
@@ -65,8 +65,8 @@ nonmemControl(
 \item{outputExtension}{Extension to use for the NONMEM output
 listing}
 
-\item{runCommand}{Command to run NONMEM (typically the path to
-"nmfe75")}
+\item{runCommand}{Command to run NONMEM (typically the path to "nmfe75") or a
+function.  See the details for more information.}
 
 \item{iniSigDig}{How many significant digits are printed in $THETA
 and $OMEGA when the estimate is zero.  Also controls the zero
@@ -120,6 +120,25 @@ babelmixr2 control option for generating NONMEM control stream and
 }
 \description{
 NONMEM estimation control
+}
+\details{
+If \code{runCommand} is given as a string, it will be called with the
+\code{system()} command like:
+
+\code{runCommand controlFile outputFile}.
+
+For example, if \code{runCommand="'/path/to/nmfe75'"} then the command line
+used would look like the following:
+
+\code{'/path/to/nmfe75' one.cmt.nmctl one.cmt.lst}
+
+If \code{runCommand} is given as a function, it will be called as
+\code{FUN(ctl, directory, ui)} to run NONMEM.  This allows you to run NONMEM
+in any way that you may need, as long as you can write it in R.  babelmixr2
+will wait for the function to return before proceeding.
+
+If \code{runCommand} is \code{NA}, \code{nlmixr()} will stop after writing
+the model files and without starting NONMEM.
 }
 \examples{
 nonmemControl()


### PR DESCRIPTION
Fix #23

This removes the "waiting for NONMEM" part.  It also allows to stop before trying to run NONMEM and return the UI object so that it can be inspected.