### PR TITLE
Pull request for lhs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Fix bug where `PopED` could error with certain `dvid` values
 
+* Fix bug where if/else clauses in the model could cause the model to
+  not predict the values correctly.
+
 # babelmixr2 0.1.4
 
 * Added experimental `PopED` integration

--- a/R/poped.R
+++ b/R/poped.R
@@ -825,7 +825,10 @@ rxUiGet.popedRxmodelBase <- function(x, ...) {
                      logical(1), USE.NAMES = FALSE))
   .mod <- .mod[.w]
   .errDf <- .iniDf[!is.na(.iniDf$err), ,drop=FALSE]
-
+  # remove if/else so extra lhs statements are not hanging around
+  .mod <- str2lang(paste0("{", rxode2::.rxPrune(as.call(c(quote(`{`), .mod))), "}"))
+  .mod <- lapply(seq_along(.mod)[-1],
+                 function(i) { .mod[[i]]})
   .mod <- lapply(seq_along(.mod),
                  function(i) {
                    .cur <- .mod[[i]]

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -594,4 +594,33 @@ if (requireNamespace("PopED", quietly=TRUE)) {
   ## test_that("example 3", {
 
   ## })
+
+  test_that("PopED lhs", {
+
+    pheno <- function() {
+      ini({
+        tcl <- log(0.008) # typical value of clearance
+        tv <-  log(0.6)   # typical value of volume
+        ## var(eta.cl)
+        eta.cl + eta.v ~ c(1,
+                           0.01, 1) ## cov(eta.cl, eta.v), var(eta.v)
+        # interindividual variability on clearance and volume
+        add.err <- 0.1    # residual variability
+      })
+      model({
+        cl <- exp(tcl + eta.cl) # individual value of clearance
+        if (fed == 1)
+          cl <- cl*1.1
+        v <- exp(tv + eta.v)    # individual value of volume
+        ke <- cl / v            # elimination rate constant
+        d/dt(A1) = - ke * A1    # model differential equation
+        cp = A1 / v             # concentration in plasma
+        cp ~ add(add.err)       # define error model
+      })
+    }
+
+    p <- pheno()
+
+    expect_equal(eval(.popedRxModel(p))$lhs, c("rx_pred_", "rx_r_"))
+  })
 }

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -622,5 +622,6 @@ if (requireNamespace("PopED", quietly=TRUE)) {
     p <- pheno()
 
     expect_equal(eval(.popedRxModel(p))$lhs, c("rx_pred_", "rx_r_"))
+
   })
 }


### PR DESCRIPTION
The `PopED` as written will have an additional `lhs` calculated for
every `if/else`. Currently this violates the assumption of the `PopED`
model which should only have 2 `lhs` values calculated.  This pull
request fixes this by pruning all the `if/else` clauses out of the
model.