### PR TITLE
fix deprecated arguments + use new ud_convert helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     rmarkdown,
     spelling,
     PopED,
-    units,
+    units (>= 0.8-6),
     vdiffr,
     dplyr
 Depends:

--- a/R/units.R
+++ b/R/units.R
@@ -103,7 +103,7 @@ modelUnitConversion <- function(dvu = NA_character_, amtu = NA_character_, timeu
     # default units for dvu with no conversion
     dvuBase <- simplifyUnit(numerator = amtu, denominator = volumeu)
     if (units::ud_are_convertible(from = dvuBase, to = dvu)) {
-      dvuConversion <- units::ud_convert(1, from = dvuBase, to = dvu)
+      dvuConversion <- units::ud_convert(dvuConversion, from = dvuBase, to = dvu)
     } else {
       dvuOrig <- dvu
       dvu <- simplifyUnit(numerator = dvu, denominator = dvuBase)

--- a/R/units.R
+++ b/R/units.R
@@ -91,9 +91,9 @@ modelUnitConversion <- function(dvu = NA_character_, amtu = NA_character_, timeu
     volumeuBase <- simplifyUnit(numerator=amtu, denominator=dvu)
     if (is.na(volumeu)) {
       # auto-generate the volumeu
-      if (units::ud_are_convertible(x = volumeuBase, y = "L")) {
+      if (units::ud_are_convertible(from = volumeuBase, to = "L")) {
         volumeu <- "L"
-      } else if (units::ud_are_convertible(x = volumeuBase, y = "mL/kg")) {
+      } else if (units::ud_are_convertible(from = volumeuBase, to = "mL/kg")) {
         volumeu <- "mL/kg"
       } else {
         volumeu <- volumeuBase
@@ -102,13 +102,8 @@ modelUnitConversion <- function(dvu = NA_character_, amtu = NA_character_, timeu
     }
     # default units for dvu with no conversion
     dvuBase <- simplifyUnit(numerator = amtu, denominator = volumeu)
-    if (units::ud_are_convertible(x = dvuBase, y = dvu)) {
-      dvuConversion <-
-        units::set_units(
-          units::as_units(x = dvuBase),
-          value = dvu,
-          mode = "standard"
-        )
+    if (units::ud_are_convertible(from = dvuBase, to = dvu)) {
+      dvuConversion <- units::ud_convert(1, from = dvuBase, to = dvu)
     } else {
       dvuOrig <- dvu
       dvu <- simplifyUnit(numerator = dvu, denominator = dvuBase)
@@ -131,6 +126,6 @@ modelUnitConversion <- function(dvu = NA_character_, amtu = NA_character_, timeu
     timeu = timeu,
     dvu = dvu,
     cmtu = dvuBase,
-    dvConversion = as.numeric(dvuConversion)
+    dvConversion = dvuConversion
   )
 }


### PR DESCRIPTION
In the current CRAN version of units (0.8-6), `ud_are_convertible` fixes the poor choice of argument names, renaming them from x, y to from, to. The old ones are still supported with a warning. This PR implements the new names to avoid that warning, and therefore I pinned the units version to >= 0.8-6. Also, this version introduces the `ud_convert` helper, which I think it's more appropriate for your use case.