### PR TITLE
Remove duplicated/masked function definitions

### DIFF
--- a/R/nonmem.R
+++ b/R/nonmem.R
@@ -527,35 +527,6 @@ rex::register_shortcuts("babelmixr2")
 .nonmemSetCmtProperty <- function(ui, state, extra, type="f") {
   .prop <- .nonmemGetCmtProperties(ui)
   .state <- rxode2::rxState(ui)
-  .cmt <- which(state == .state)
-  .w <- which(.prop$cmt == .cmt)
-  if (length(.w) == 0L) {
-    .prop <- rbind(.prop,
-                   data.frame(cmt=.cmt,
-                              f=NA_character_,
-                              dur=NA_character_,
-                              lag=NA_character_,
-                              rate=NA_character_,
-                              init=NA_character_))
-    .w <- which(.prop$cmt == .cmt)
-  }
-  if (type == "f") {
-    .prop[.w, "f"] <- extra
-  } else if (type == "dur") {
-    .prop[.w, "dur"] <- extra
-  } else if (type == "lag") {
-    .prop[.w, "lag"] <- extra
-  } else if (type == "rate") {
-    .prop[.w, "rate"] <- extra
-  } else if (type == "init") {
-    .prop[.w, "init"] <- extra
-  }
-  rxode2::rxAssignControlValue(ui, ".cmtProperties", .prop)
-}
-
-.nonmemSetCmtProperty <- function(ui, state, extra, type="f") {
-  .prop <- .nonmemGetCmtProperties(ui)
-  .state <- rxode2::rxState(ui)
   .cmt <- .rxGetCmtNumber(state, ui)
   .w <- which(.prop$cmt == .cmt)
   if (length(.w) == 0L) {

--- a/R/nonmemControl.R
+++ b/R/nonmemControl.R
@@ -295,25 +295,6 @@ nmObjGetControl.nonmem <- function(x, ...) {
   stop("cannot find nonmem related control object", call.=FALSE)
 }
 
-#' @export
-nmObjHandleControlObject.nonmemControl <- function(control, env) {
-  assign("nonmemControl", control, envir=env)
-}
-
-#' @export
-nmObjGetControl.nonmem <- function(x, ...) {
-  .env <- x[[1]]
-  if (exists("nonmemControl", .env)) {
-    .control <- get("nonmemControl", .env)
-    if (inherits(.control, "nonmemControl")) return(.control)
-  }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
-    if (inherits(.control, "nonmemControl")) return(.control)
-  }
-  stop("cannot find nonmem related control object", call.=FALSE)
-}
-
 .nonmemControlToFoceiControl <- function(env, assign=FALSE) {
   .nonmemControl <- env$nonmemControl
   .ui <- env$ui


### PR DESCRIPTION
R sources files alphabetically and the later definition silently masks the earlier, so these duplicates were dead code:

- .nonmemSetCmtProperty (nonmem.R): defined twice; the dead earlier copy used fragile string equality 'which(state == .state)' while the live copy uses .rxGetCmtNumber(state, ui). Removed the dead copy (behavior unchanged).
- nmObjHandleControlObject.nonmemControl / nmObjGetControl.nonmem (nonmemControl.R): an identical block was pasted twice. Removed the duplicate.