### PR TITLE
Remove dead, colliding isSameTime/max2 macros from poped.cpp

### DIFF
--- a/src/poped.cpp
+++ b/src/poped.cpp
@@ -231,9 +231,6 @@ Rcpp::NumericVector popedMultipleEndpointParam(Rcpp::NumericVector p,
   return ret;
 }
 
-#define max2( a , b )  ( (a) > (b) ? (a) : (b) )
-#define isSameTime(xout, xp) (fabs((xout)-(xp))  <= DBL_EPSILON*max2(fabs(xout),fabs(xp)))
-
 extern "C" {
 #define iniRxodePtrs _babelmixr2_iniRxodePtrs
   iniRxode2ptr


### PR DESCRIPTION
## What

`poped.cpp` defined `isSameTime()` (and helper `max2()`), colliding with the `isSameTime()` rxode2 now exports via `rxode2.h` (pulled in through `rxode2ptr.h`):

```
poped.cpp:235: warning: "isSameTime" redefined
```

## Why

The two definitions differ — `poped.cpp` used `DBL_EPSILON`, rxode2.h uses `2.0*DBL_EPSILON` — a silent divergence. Both macros are **unused** in `poped.cpp`, so they're removed. No behavior change; the warning (and the silent semantic divergence) is gone.

## Verification

`poped.cpp` recompiles clean: 1 → 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)