### PR TITLE
Fix NONMEM export silently dropping absorption lag (#190)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # babelmixr2 0.1.11.9000
 
+* Fix NONMEM export silently dropping the absorption lag (#190).  A
+  `lag(depot)`/`alag(depot)` assignment computed the lag parameter in `$PK`
+  but never emitted the corresponding `ALAG<n>=` statement, so NONMEM fit the
+  model without any lag.  The lag value is now assigned to `ALAG<n>` in `$PK`.
+
 * Added `nlmer` estimation method: fits nlmixr2 models via `lme4::nlmer` using
   analytical gradients from rxode2 sensitivity equations. Supports
   mu-referenced and non-mu-referenced random-effects models. Access via

--- a/R/nonmem.R
+++ b/R/nonmem.R
@@ -527,35 +527,6 @@ rex::register_shortcuts("babelmixr2")
 .nonmemSetCmtProperty <- function(ui, state, extra, type="f") {
   .prop <- .nonmemGetCmtProperties(ui)
   .state <- rxode2::rxState(ui)
-  .cmt <- which(state == .state)
-  .w <- which(.prop$cmt == .cmt)
-  if (length(.w) == 0L) {
-    .prop <- rbind(.prop,
-                   data.frame(cmt=.cmt,
-                              f=NA_character_,
-                              dur=NA_character_,
-                              lag=NA_character_,
-                              rate=NA_character_,
-                              init=NA_character_))
-    .w <- which(.prop$cmt == .cmt)
-  }
-  if (type == "f") {
-    .prop[.w, "f"] <- extra
-  } else if (type == "dur") {
-    .prop[.w, "dur"] <- extra
-  } else if (type == "lag") {
-    .prop[.w, "lag"] <- extra
-  } else if (type == "rate") {
-    .prop[.w, "rate"] <- extra
-  } else if (type == "init") {
-    .prop[.w, "init"] <- extra
-  }
-  rxode2::rxAssignControlValue(ui, ".cmtProperties", .prop)
-}
-
-.nonmemSetCmtProperty <- function(ui, state, extra, type="f") {
-  .prop <- .nonmemGetCmtProperties(ui)
-  .state <- rxode2::rxState(ui)
   .cmt <- .rxGetCmtNumber(state, ui)
   .w <- which(.prop$cmt == .cmt)
   if (length(.w) == 0L) {
@@ -572,12 +543,15 @@ rex::register_shortcuts("babelmixr2")
     .prop[.w, "f"] <- extra
   } else if (type == "dur") {
     .prop[.w, "dur"] <- extra
-  } else if (type == "lag") {
+  } else if (type == "lag" || type == "alag") {
+    # lag(cmt)/alag(cmt) both resolve to prefix "alag" upstream; store in lag column
     .prop[.w, "lag"] <- extra
   } else if (type == "rate") {
     .prop[.w, "rate"] <- extra
   } else if (type == "init") {
     .prop[.w, "init"] <- extra
+  } else {
+    stop("unknown compartment property type: ", type, call.=FALSE)
   }
   rxode2::rxAssignControlValue(ui, ".cmtProperties", .prop)
 }

--- a/tests/testthat/test-nonmem.R
+++ b/tests/testthat/test-nonmem.R
@@ -286,6 +286,47 @@ withr::with_tempdir({
 
     })
 
+    test_that("NONMEM export assigns ALAG for absorption lag (issue #190)", {
+      # lag(depot)/alag(depot) must produce a real ALAG<n>= statement in $PK,
+      # otherwise NONMEM silently fits the model without the absorption lag.
+      lagDirect <- function() {
+        ini({ lka <- 0.45; lcl <- 1; lvc <- 3.45; llagt <- log(0.3)
+              eta.cl ~ 0.1; propSd <- 0.5 })
+        model({ ka <- exp(lka); cl <- exp(lcl + eta.cl); vc <- exp(lvc)
+                lag(depot) <- exp(llagt)
+                d/dt(depot)  <- -ka * depot
+                d/dt(center) <-  ka * depot - (cl / vc) * center
+                cp <- center / vc
+                cp ~ prop(propSd) })
+      }
+      lagVar <- function() {
+        ini({ lka <- 0.45; lcl <- 1; lvc <- 3.45; llagt <- log(0.3)
+              eta.cl ~ 0.1; propSd <- 0.5 })
+        model({ ka <- exp(lka); cl <- exp(lcl + eta.cl); vc <- exp(lvc)
+                lagt <- exp(llagt)
+                lag(depot) <- lagt
+                d/dt(depot)  <- -ka * depot
+                d/dt(center) <-  ka * depot - (cl / vc) * center
+                cp <- center / vc
+                cp ~ prop(propSd) })
+      }
+      alagVar <- function() {
+        ini({ lka <- 0.45; lcl <- 1; lvc <- 3.45; llagt <- log(0.3)
+              eta.cl ~ 0.1; propSd <- 0.5 })
+        model({ ka <- exp(lka); cl <- exp(lcl + eta.cl); vc <- exp(lvc)
+                lagt <- exp(llagt)
+                alag(depot) <- lagt
+                d/dt(depot)  <- -ka * depot
+                d/dt(center) <-  ka * depot - (cl / vc) * center
+                cp <- center / vc
+                cp ~ prop(propSd) })
+      }
+      for (m in list(lagDirect, lagVar, alagVar)) {
+        nm <- m()$nonmemModel
+        expect_match(nm, "ALAG1 *=", all=FALSE)
+      }
+    })
+
     # pk.turnover.emax3 <- function() {
     #   ini({
     #     tktr <- log(1)


### PR DESCRIPTION
Fixes #190.

## Problem

`babelmixr2` translated a model containing `lag(depot) <- ...` into a NONMEM control stream that computed the lag parameter in `$PK` but **never assigned it to `ALAG<n>`**. NONMEM then silently fit the model without any absorption lag -- a silent wrong answer.

## Root cause

`.rxToNonmemHandleAssignmentPrefix` maps both `lag(cmt)` and `alag(cmt)` to the prefix `"alag"`, then calls `.nonmemSetCmtProperty(..., type="alag")`. But `.nonmemSetCmtProperty` only handled `type` in `f`/`dur`/`lag`/`rate`/`init` -- there was no `alag` branch, so the lag value silently matched nothing and was never stored. The downstream `!is.na(.prop$lag[i])` gate in `rxUiGet.nonmemPkDesErr0` therefore never fired.

## Fix

- Add an `alag` branch (mapping to the `lag` column) in `.nonmemSetCmtProperty`.
- Add a catch-all `stop()` so an unknown property type is loud, not silent.
- Remove the dead duplicate first definition of `.nonmemSetCmtProperty` (the second definition always shadowed it).

## Verification

All three spellings from the issue now emit `ALAG1=`:

| syntax | `ALAG<n>=` emitted? |
|---|---|
| `lag(depot) <- exp(llagt)` | yes |
| `lagt <- exp(llagt); lag(depot) <- lagt` | yes |
| `lagt <- exp(llagt); alag(depot) <- lagt` | yes |

Added a regression test (`test-nonmem.R`) asserting `ALAG1=` appears in `ui$nonmemModel` for all three spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)