### PR TITLE
Announce NONMEM reserved-name variable renames (#190 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
   but never emitted the corresponding `ALAG<n>=` statement, so NONMEM fit the
   model without any lag.  The lag value is now assigned to `ALAG<n>` in `$PK`.
 
+* NONMEM export now announces when a model variable is renamed because it
+  collides with a NONMEM reserved name (e.g. a variable named `alag` becomes
+  `RXR1`).  The rename was previously silent (#190).
+
 * Added `nlmer` estimation method: fits nlmixr2 models via `lme4::nlmer` using
   analytical gradients from rxode2 sensitivity equations. Supports
   mu-referenced and non-mu-referenced random-effects models. Access via

--- a/R/nonmem.R
+++ b/R/nonmem.R
@@ -171,6 +171,8 @@ rex::register_shortcuts("babelmixr2")
     rxode2::rxAssignControlValue(ui, ".nmVarResNum", .num + 1)
     .reserved <- rbind(.reserved, data.frame(var=var, nm=.newVar))
     rxode2::rxAssignControlValue(ui, ".nmGetVarReservedDf", .reserved)
+    rxode2::.minfo(paste0("renamed model variable '", var, "' to '", .newVar,
+                          "' because '", .uvar, "' collides with a NONMEM reserved name"))
     var <- .newVar
   }
   .uvar <- gsub(".", "_", toupper(var), fixed=TRUE)

--- a/tests/testthat/test-nonmem.R
+++ b/tests/testthat/test-nonmem.R
@@ -327,6 +327,26 @@ withr::with_tempdir({
       }
     })
 
+    test_that("NONMEM reserved-name variable rename is announced (issue #190)", {
+      # A plain model variable colliding with a NONMEM reserved name is renamed
+      # to RXR<n>; the rename must not be silent.
+      reservedVar <- function() {
+        ini({ lka <- 0.45; lcl <- 1; lvc <- 3.45; lalag <- log(0.3)
+              eta.cl ~ 0.1; propSd <- 0.5 })
+        model({ ka <- exp(lka); cl <- exp(lcl + eta.cl); vc <- exp(lvc)
+                alag <- exp(lalag)
+                d/dt(depot)  <- -ka * depot
+                d/dt(center) <-  ka * depot - (cl / vc) * center
+                cp <- center / vc * alag
+                cp ~ prop(propSd) })
+      }
+      expect_message(
+        nm <- reservedVar()$nonmemModel,
+        regexp="renamed model variable 'alag' to 'RXR1'"
+      )
+      expect_match(nm, "RXR1 *=", all=FALSE)
+    })
+
     # pk.turnover.emax3 <- function() {
     #   ini({
     #     tktr <- log(1)


### PR DESCRIPTION
Follow-up to #192 (issue #190).

## Background

Issue #190 noted, as a secondary point, that naming a plain model variable `alag` gets it silently renamed to `RXR1` in the NONMEM export.

On investigation this rename is **correct and safe**: `ALAG` collides with NONMEM's reserved `ALAG` namespace, so `.nmGetVar` renames it and rewrites every reference consistently -- the translated model is still right. Loosening the reserved-word protection would risk reintroducing exactly the class of silent wrong-answer bug that #190 is about, so that is deliberately not changed here.

The real problem was that the rename was **silent**, leaving users to find an unexplained `RXR1` in their output.

## Change

Emit a one-time `.minfo` message at the rename site naming the original variable, the replacement, and the reserved name it collided with:

```
i renamed model variable 'alag' to 'RXR1' because 'ALAG' collides with a NONMEM reserved name
```

The rename is recorded once per unique variable, so the message fires once, not per lookup.

Added a regression test asserting the message is emitted (and that the renamed `RXR1=` still appears in the control stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)