### PR TITLE
fmeMcmc: back-transform the mcmc chain and add a reproducible seed

### DIFF
--- a/R/fmeMcmc.R
+++ b/R/fmeMcmc.R
@@ -9,6 +9,13 @@
 #' @param returnFmeMcmc return the fmeMcmc output instead of the nlmixr2
 #'   fit
 #'
+#' @param seed an integer seed used for the mcmc chain.  The chain is
+#'   fully determined by this seed, so a fixed value makes the fit
+#'   reproducible.  The run is wrapped in [rxode2::rxWithSeed()], which
+#'   restores the prior random number generator state afterward, so
+#'   seeding the fit does not disturb the calling session's stream.  Vary
+#'   this to explore different chains.
+#'
 #' @return fmeMcmc control structure
 #' @export
 #' @author Matthew L. Fidler
@@ -62,6 +69,7 @@ fmeMcmcControl <- function(jump=NULL,
                            ntrydr = 1,
                            drscale = NULL,
                            verbose = FALSE,
+                           seed = 99,
                            returnFmeMcmc=FALSE,
 
                            # rxode2/nlmixr2est options
@@ -109,6 +117,7 @@ fmeMcmcControl <- function(jump=NULL,
     call.=FALSE)
   }
 
+  checkmate::assertIntegerish(seed, any.missing=FALSE, len=1)
   checkmate::assertIntegerish(stickyRecalcN, any.missing=FALSE, lower=0, len=1)
   checkmate::assertIntegerish(maxOdeRecalc, any.missing=FALSE, len=1)
   checkmate::assertNumeric(odeRecalcFactor, len=1, lower=1, any.missing=FALSE)
@@ -177,6 +186,7 @@ fmeMcmcControl <- function(jump=NULL,
     ntrydr = as.integer(ntrydr),
     drscale = drscale,
     verbose = as.logical(verbose),
+    seed = as.integer(seed),
     covMethod=match.arg(covMethod),
     optExpression=optExpression,
     literalFix=literalFix,
@@ -313,7 +323,7 @@ getValidNlmixrCtl.fmeMcmc <- function(control) {
   if (is.null(.ctl$covscale)) {
     .ctl$covscale <- 2.4^2 / length(.env$par.ini)
   }
-  .ret <- bquote(FME::modMCMC(
+  .mcmcCall <- bquote(FME::modMCMC(
     f=.(babelmixr2::.fmeMcmcF),
     p=.(.env$par.ini),
     lower=.(.env$lower),
@@ -327,7 +337,11 @@ getValidNlmixrCtl.fmeMcmc <- function(control) {
     ntrydr=.(.ctl$ntrydr),
     drscale=.(.ctl$drscale),
     verbose=.(.ctl$verbose)))
-  .ret <- eval(.ret)
+  # `FME::modMCMC()` proposes jumps with R's random number generator, so the
+  # chain is fully determined by the seed.  Run it under `rxWithSeed()` so the
+  # fit is reproducible for a given `seed` and the caller's random number stream
+  # is restored afterward.
+  .ret <- rxode2::rxWithSeed(.ctl$seed, eval(.mcmcCall))
   # `FME::modMCMC()` explores the internal, scaled optimization space, so the
   # sampled chain (`$pars`) is on that scale rather than the natural one -- it
   # wanders around the scaled starting point (~1) instead of the `ini({})`

--- a/R/fmeMcmc.R
+++ b/R/fmeMcmc.R
@@ -328,9 +328,35 @@ getValidNlmixrCtl.fmeMcmc <- function(control) {
     drscale=.(.ctl$drscale),
     verbose=.(.ctl$verbose)))
   .ret <- eval(.ret)
+  # `FME::modMCMC()` explores the internal, scaled optimization space, so the
+  # sampled chain (`$pars`) is on that scale rather than the natural one -- it
+  # wanders around the scaled starting point (~1) instead of the `ini({})`
+  # values.  Back-transform the whole chain (issue #178) so that summaries of
+  # `fit$fmeMcmc` -- `summary()`, `coda::as.mcmc()`, `pairs()` -- report the
+  # actual sampled parameters and agree with `print(fit)`.  `$bestpar` is
+  # back-transformed separately by `.nlmFinalizeList()` below.
+  #
+  # `modMCMC()` also labels the columns generically (`p1`, `p2`, ...) because the
+  # scaled starting vector it is handed is unnamed, so relabel them with the real
+  # parameter names (issue #178 also noted the confusing `p7`-style names).
+  #
+  # `nlmixr2est::nlmUnscalePar()` is unexported, so reach it through the
+  # namespace (avoids a CRAN-flagged `:::` call).  It unscales by position, so
+  # the chain columns must stay in `thetaNames` order.
+  .unscalePar <- get("nlmUnscalePar", envir=asNamespace("nlmixr2est"))
+  .parNames <- .env$thetaNames
+  .chain <- .ret$pars
+  for (.i in seq_len(nrow(.chain))) {
+    .chain[.i, ] <- .unscalePar(setNames(.ret$pars[.i, ], .parNames))
+  }
+  colnames(.chain) <- .parNames
+  .ret$pars <- .chain
   if (.ctl$covMethod == "mcmc") {
+    # Every nlm scaling is a per-parameter affine map, so the sample covariance
+    # of the back-transformed chain is exactly the scale-adjusted covariance
+    # that `.nlmAdjustCov()` used to produce from the scaled chain.
     .ret$cov.unscaled <- cov(.ret$pars)
-    .ret$cov <- nlmixr2est::.nlmAdjustCov(.ret$cov.unscaled, .ret$bestpar)
+    .ret$cov <- .ret$cov.unscaled
   }
   .ret <- nlmixr2est::.nlmFinalizeList(.env, .ret, par="bestpar", printLine=TRUE,
                                        hessianCov=(.ctl$covMethod == "r"))

--- a/man/fmeMcmcControl.Rd
+++ b/man/fmeMcmcControl.Rd
@@ -15,6 +15,7 @@ fmeMcmcControl(
   ntrydr = 1,
   drscale = NULL,
   verbose = FALSE,
+  seed = 99,
   returnFmeMcmc = FALSE,
   stickyRecalcN = 4,
   maxOdeRecalc = 5,
@@ -92,6 +93,13 @@ fmeMcmcControl(
     numeric value \code{i > 1}, prints status information every 
 	\code{i} iterations.
   }
+
+\item{seed}{an integer seed used for the mcmc chain.  The chain is
+fully determined by this seed, so a fixed value makes the fit
+reproducible.  The run is wrapped in \code{\link[rxode2:rxWithSeed]{rxode2::rxWithSeed()}}, which
+restores the prior random number generator state afterward, so
+seeding the fit does not disturb the calling session's stream.  Vary
+this to explore different chains.}
 
 \item{returnFmeMcmc}{return the fmeMcmc output instead of the nlmixr2
 fit}

--- a/tests/testthat/test-fmeMcmc.R
+++ b/tests/testthat/test-fmeMcmc.R
@@ -34,6 +34,27 @@ test_that("fmeMcmc works", {
 
     expect_s3_class(coda::as.mcmc(fit2), "mcmc")
 
+    # issue #178: when the chain is explored in a scaled space, `$pars` must be
+    # back-transformed to the natural parameter space.
+    .chain <- fit2$fmeMcmc$pars
+
+    # the chain columns carry the real parameter names, not FME's generic
+    # `p1`/`p2`/... labels
+    expect_setequal(colnames(.chain), c("E0", "Em", "E50"))
+
+    # the natural-scale fixed-effect estimates lie within the explored chain.
+    # `Estimate` is `bestpar`, which is by definition a member of the chain, so
+    # this holds exactly for a back-transformed chain -- but fails for the old
+    # scaled chain, whose samples cluster near the ~1 scaled starting point.
+    .est <- setNames(fit2$parFixedDf$Estimate, rownames(fit2$parFixedDf))
+    .est <- .est[colnames(.chain)]
+    expect_true(all(.est >= apply(.chain, 2L, min) &
+                      .est <= apply(.chain, 2L, max)))
+
+    # the covariance (used for the standard errors) is the sample covariance of
+    # the back-transformed chain
+    expect_equal(fit2$fmeMcmc$cov, stats::cov(.chain))
+
   })
 
 

--- a/tests/testthat/test-fmeMcmc.R
+++ b/tests/testthat/test-fmeMcmc.R
@@ -59,3 +59,41 @@ test_that("fmeMcmc works", {
 
 
 })
+
+test_that("fmeMcmc chain is determined by control's seed", {
+  skip_if_not_installed("FME")
+  skip_on_cran()
+
+  dsn <- rxode2::rxWithSeed(42, {
+    .d <- data.frame(i=1:1000)
+    .d$time <- exp(rnorm(1000))
+    .d$DV <- rbinom(1000, 1, exp(-1+.d$time)/(1+exp(-1+.d$time)))
+    .d
+  })
+
+  mod <- function() {
+    ini({
+      E0 <- 0.5
+      Em <- 0.5
+      E50 <- 2
+      g <- fix(2)
+    })
+    model({
+      v <- E0+Em*time^g/(E50^g+time^g)
+      ll(bin) ~ DV * v - log(1 + exp(v))
+    })
+  }
+
+  .fit <- function(seed) {
+    suppressMessages(nlmixr(mod, dsn, est="fmeMcmc",
+                            control=fmeMcmcControl(print=0, niter=50,
+                                                   seed=seed)))$fmeMcmc$pars
+  }
+
+  # the run is wrapped in rxWithSeed(), so the same seed reproduces the chain
+  # exactly even though the two fits run back-to-back from different RNG states
+  expect_equal(.fit(42), .fit(42))
+
+  # ... and a different seed explores a different chain
+  expect_false(isTRUE(all.equal(.fit(42), .fit(7))))
+})


### PR DESCRIPTION
Fixes #178.

## Back-transform the mcmc chain (issue #178)

`FME::modMCMC()` explores the internal, **scaled** optimization space, so the sampled chain (`$pars`) was left on that scale. `$bestpar` was already back-transformed by `.nlmFinalizeList()` (so `print(fit)` was correct) and the covariance was scale-adjusted via `.nlmAdjustCov()`, but the chain itself was not. That caused both problems reported on the issue:

- the chain wandered around the scaled starting point (~1) rather than the `ini({})` values, and
- `summary(fit$fmeMcmc)` / `coda::as.mcmc()` / `pairs()` disagreed with `print(fit)`.

This back-transforms the whole chain via `nlmixr2est`'s `nlmUnscalePar()` and takes the mcmc covariance (and hence the SEs) directly from the back-transformed chain. Because every nlm scaling is a **per-parameter affine map**, that sample covariance is exactly what `.nlmAdjustCov()` previously produced from the scaled chain, so **the SEs are unchanged**.

It also relabels the chain columns with the real parameter names — `modMCMC()` labels them generically (`p1`, `p2`, …) because the scaled starting vector it is handed is unnamed, which is what made the error term show up as an inscrutable `p7`.

## Reproducible seed

`modMCMC()` proposes its jumps with R's RNG, so the chain — and therefore the estimates and covariance — was determined by whatever RNG state the caller happened to be in, making fits irreproducible. This adds a `seed` argument to `fmeMcmcControl()` (default `99`, matching `saemControl()`) and wraps the run in `rxode2::rxWithSeed()`. A given seed now reproduces the chain exactly, and `rxWithSeed()` restores the caller's RNG stream afterward so seeding the fit does not disturb the surrounding session.

## Tests

`tests/testthat/test-fmeMcmc.R`:

- the back-transformed chain carries the real parameter names, and the natural-scale estimates lie within the chain (a deterministic check that fails on the old scaled chain, whose samples cluster near the ~1 starting point);
- the mcmc covariance equals `stats::cov()` of the back-transformed chain;
- the same seed reproduces the chain byte-for-byte across back-to-back fits, and a different seed diverges.

All 8 tests pass.