### PR TITLE
Fix stale nlmerControl iterPrintControl test (print = 1L default)

### DIFF
--- a/tests/testthat/test-iterPrintControl.R
+++ b/tests/testthat/test-iterPrintControl.R
@@ -1,7 +1,8 @@
 test_that("nlmerControl absorbs print/printNcol/useColor into iterPrintControl", {
   .ctl <- nlmerControl()
   expect_s3_class(.ctl$iterPrintControl, "iterPrintControl")
-  expect_equal(.ctl$iterPrintControl$every, 0L)
+  # nlmerControl() defaults to print = 1L so nlmer iterations print by default
+  expect_equal(.ctl$iterPrintControl$every, 1L)
   expect_null(.ctl[["print"]])
   expect_null(.ctl[["printNcol"]])
   expect_null(.ctl[["useColor"]])


### PR DESCRIPTION
## Problem

`test-iterPrintControl.R` fails:

```
FAILURE ('test-iterPrintControl.R:4'): nlmerControl absorbs print/printNcol/useColor into iterPrintControl
Expected `.ctl$iterPrintControl$every` to equal 0L.
```

## Cause

The test (added in `920fba6`, "Extend iterPrintControl unification to nlmer and
saemix methods") asserted that `nlmerControl()`'s default absorbs to
`iterPrintControl$every == 0L`. Shortly after, `cd8a2cd9` ("nlmer: print
iterations and recover parameter history from nlm") **intentionally** changed
`nlmerControl()`'s default from `print = 0L` to `print = 1L` so nlmer iterations
print by default -- which absorbs to `every == 1L` -- but did not update the
test. The test has been stale ever since.

## Fix

Update the default expectation to `1L` to match the intended `print = 1L`
default. `saemixControl()` still defaults `print = FALSE` -> `every == 0L`, and
that assertion is unchanged.

Test-only change. Verified: `test-iterPrintControl.R` now passes (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)