### PR TITLE
Fix roxygen2 S3 detection: quote non-syntactic @importFrom names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Config/testthat/edition: 3
 LinkingTo:
     Rcpp, rxode2, RcppArmadillo, RcppEigen
 Language: en-US
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -313,139 +313,155 @@ export(vpcSim)
 import(nlmixr2data)
 import(nlmixr2plot)
 importFrom(lotri,lotri)
-importFrom(magrittr,`%>%`)
+importFrom(magrittr,"%>%")
 importFrom(methods,is)
-importFrom(monolix2rx,mlxtran)
-importFrom(monolix2rx,monolix2rx)
-importFrom(nlmixr2est,.nlmixrNlmeFun)
-importFrom(nlmixr2est,ACF)
-importFrom(nlmixr2est,VarCorr)
-importFrom(nlmixr2est,addCwres)
-importFrom(nlmixr2est,addNpde)
-importFrom(nlmixr2est,addTable)
-importFrom(nlmixr2est,augPred)
-importFrom(nlmixr2est,bobyqaControl)
-importFrom(nlmixr2est,fixed.effects)
-importFrom(nlmixr2est,fixef)
-importFrom(nlmixr2est,foceiControl)
-importFrom(nlmixr2est,getData)
-importFrom(nlmixr2est,getValidNlmixrCtl)
-importFrom(nlmixr2est,getVarCov)
-importFrom(nlmixr2est,groupedData)
-importFrom(nlmixr2est,iterPrintControl)
-importFrom(nlmixr2est,lbfgsb3cControl)
-importFrom(nlmixr2est,n1qn1Control)
-importFrom(nlmixr2est,newuoaControl)
-importFrom(nlmixr2est,nlmControl)
-importFrom(nlmixr2est,nlme)
-importFrom(nlmixr2est,nlmeControl)
-importFrom(nlmixr2est,nlminbControl)
-importFrom(nlmixr2est,nlmixr)
-importFrom(nlmixr2est,nlmixr2)
-importFrom(nlmixr2est,nlmixr2AllEst)
-importFrom(nlmixr2est,nlmixr2Est)
-importFrom(nlmixr2est,nlmixr2NlmeControl)
-importFrom(nlmixr2est,nlsControl)
-importFrom(nlmixr2est,nmObjGetControl)
-importFrom(nlmixr2est,nmObjGetFoceiControl)
-importFrom(nlmixr2est,nmObjHandleControlObject)
-importFrom(nlmixr2est,optimControl)
-importFrom(nlmixr2est,pdBlocked)
-importFrom(nlmixr2est,pdCompSymm)
-importFrom(nlmixr2est,pdConstruct)
-importFrom(nlmixr2est,pdDiag)
-importFrom(nlmixr2est,pdFactor)
-importFrom(nlmixr2est,pdIdent)
-importFrom(nlmixr2est,pdLogChol)
-importFrom(nlmixr2est,pdMat)
-importFrom(nlmixr2est,pdMatrix)
-importFrom(nlmixr2est,pdNatural)
-importFrom(nlmixr2est,pdSymm)
-importFrom(nlmixr2est,random.effects)
-importFrom(nlmixr2est,ranef)
-importFrom(nlmixr2est,reStruct)
-importFrom(nlmixr2est,saemControl)
-importFrom(nlmixr2est,setOfv)
-importFrom(nlmixr2est,tableControl)
-importFrom(nlmixr2est,uobyqaControl)
-importFrom(nlmixr2est,varComb)
-importFrom(nlmixr2est,varConstPower)
-importFrom(nlmixr2est,varExp)
-importFrom(nlmixr2est,varFixed)
-importFrom(nlmixr2est,varFunc)
-importFrom(nlmixr2est,varIdent)
-importFrom(nlmixr2est,varPower)
-importFrom(nlmixr2est,varWeights)
-importFrom(nlmixr2est,vpcSim)
-importFrom(nlmixr2extra,bootplot)
-importFrom(nlmixr2extra,bootstrapFit)
-importFrom(nlmixr2extra,preconditionFit)
-importFrom(nlmixr2extra,profileFixed)
-importFrom(nlmixr2extra,profileFixedSingle)
-importFrom(nlmixr2extra,profileLlp)
-importFrom(nlmixr2plot,traceplot)
-importFrom(nlmixr2plot,vpcCens)
-importFrom(nlmixr2plot,vpcCensTad)
-importFrom(nlmixr2plot,vpcPlot)
-importFrom(nlmixr2plot,vpcPlotTad)
-importFrom(nonmem2rx,as.nonmem2rx)
-importFrom(nonmem2rx,nmcov)
-importFrom(nonmem2rx,nmext)
-importFrom(nonmem2rx,nminfo)
-importFrom(nonmem2rx,nmtab)
-importFrom(nonmem2rx,nmxml)
-importFrom(nonmem2rx,nonmem2rx)
-importFrom(rxode2,.minfo)
-importFrom(rxode2,RxODE)
-importFrom(rxode2,`ini<-`)
-importFrom(rxode2,`model<-`)
-importFrom(rxode2,add.dosing)
-importFrom(rxode2,add.sampling)
-importFrom(rxode2,et)
-importFrom(rxode2,etExpand)
-importFrom(rxode2,eventTable)
-importFrom(rxode2,expit)
-importFrom(rxode2,geom_amt)
-importFrom(rxode2,geom_cens)
-importFrom(rxode2,ini)
-importFrom(rxode2,logit)
-importFrom(rxode2,lotri)
-importFrom(rxode2,model)
-importFrom(rxode2,probit)
-importFrom(rxode2,probitInv)
-importFrom(rxode2,rxCat)
-importFrom(rxode2,rxClean)
-importFrom(rxode2,rxControl)
-importFrom(rxode2,rxDerived)
-importFrom(rxode2,rxFun)
-importFrom(rxode2,rxModelVars)
-importFrom(rxode2,rxParam)
-importFrom(rxode2,rxParams)
-importFrom(rxode2,rxSetPipingAuto)
-importFrom(rxode2,rxSetSeed)
-importFrom(rxode2,rxSolve)
-importFrom(rxode2,rxUiGet)
-importFrom(rxode2,rxode)
-importFrom(rxode2,rxode2)
-importFrom(rxode2,stat_amt)
-importFrom(rxode2,stat_cens)
-importFrom(stats,approxfun)
-importFrom(stats,as.formula)
-importFrom(stats,cov)
-importFrom(stats,cov2cor)
-importFrom(stats,dlnorm)
-importFrom(stats,logLik)
-importFrom(stats,median)
-importFrom(stats,na.fail)
-importFrom(stats,na.omit)
-importFrom(stats,pchisq)
-importFrom(stats,predict)
-importFrom(stats,qchisq)
-importFrom(stats,qnorm)
-importFrom(stats,setNames)
-importFrom(stats,sigma)
-importFrom(stats,vcov)
-importFrom(utils,assignInMyNamespace)
-importFrom(utils,read.csv)
-importFrom(utils,write.csv)
+importFrom(monolix2rx,
+  mlxtran,
+  monolix2rx
+)
+importFrom(nlmixr2est,
+  .nlmixrNlmeFun,
+  ACF,
+  VarCorr,
+  addCwres,
+  addNpde,
+  addTable,
+  augPred,
+  bobyqaControl,
+  fixed.effects,
+  fixef,
+  foceiControl,
+  getData,
+  getValidNlmixrCtl,
+  getVarCov,
+  groupedData,
+  iterPrintControl,
+  lbfgsb3cControl,
+  n1qn1Control,
+  newuoaControl,
+  nlmControl,
+  nlme,
+  nlmeControl,
+  nlminbControl,
+  nlmixr,
+  nlmixr2,
+  nlmixr2AllEst,
+  nlmixr2Est,
+  nlmixr2NlmeControl,
+  nlsControl,
+  nmObjGetControl,
+  nmObjGetFoceiControl,
+  nmObjHandleControlObject,
+  optimControl,
+  pdBlocked,
+  pdCompSymm,
+  pdConstruct,
+  pdDiag,
+  pdFactor,
+  pdIdent,
+  pdLogChol,
+  pdMat,
+  pdMatrix,
+  pdNatural,
+  pdSymm,
+  random.effects,
+  ranef,
+  reStruct,
+  saemControl,
+  setOfv,
+  tableControl,
+  uobyqaControl,
+  varComb,
+  varConstPower,
+  varExp,
+  varFixed,
+  varFunc,
+  varIdent,
+  varPower,
+  varWeights,
+  vpcSim
+)
+importFrom(nlmixr2extra,
+  bootplot,
+  bootstrapFit,
+  preconditionFit,
+  profileFixed,
+  profileFixedSingle,
+  profileLlp
+)
+importFrom(nlmixr2plot,
+  traceplot,
+  vpcCens,
+  vpcCensTad,
+  vpcPlot,
+  vpcPlotTad
+)
+importFrom(nonmem2rx,
+  as.nonmem2rx,
+  nmcov,
+  nmext,
+  nminfo,
+  nmtab,
+  nmxml,
+  nonmem2rx
+)
+importFrom(rxode2,
+  "ini<-",
+  "model<-",
+  .minfo,
+  RxODE,
+  add.dosing,
+  add.sampling,
+  et,
+  etExpand,
+  eventTable,
+  expit,
+  geom_amt,
+  geom_cens,
+  ini,
+  logit,
+  lotri,
+  model,
+  probit,
+  probitInv,
+  rxCat,
+  rxClean,
+  rxControl,
+  rxDerived,
+  rxFun,
+  rxModelVars,
+  rxParam,
+  rxParams,
+  rxSetPipingAuto,
+  rxSetSeed,
+  rxSolve,
+  rxUiGet,
+  rxode,
+  rxode2,
+  stat_amt,
+  stat_cens
+)
+importFrom(stats,
+  approxfun,
+  as.formula,
+  cov,
+  cov2cor,
+  dlnorm,
+  logLik,
+  median,
+  na.fail,
+  na.omit,
+  pchisq,
+  predict,
+  qchisq,
+  qnorm,
+  setNames,
+  sigma,
+  vcov
+)
+importFrom(utils,
+  assignInMyNamespace,
+  read.csv,
+  write.csv
+)
 useDynLib(babelmixr2, .registration=TRUE)

--- a/R/monolixControl.R
+++ b/R/monolixControl.R
@@ -68,7 +68,7 @@
 #' @importFrom methods is
 #' @importFrom stats na.omit setNames
 #' @importFrom utils assignInMyNamespace read.csv write.csv
-#' @importFrom rxode2 `model<-`
+#' @importFrom rxode2 "model<-"
 monolixControl <- function(nbSSDoses=7,
                            useLinearization=FALSE,
                            stiff=FALSE,

--- a/R/reexports.R
+++ b/R/reexports.R
@@ -4,7 +4,7 @@
 #' @export
 lotri::lotri
 
-#' @importFrom magrittr `%>%`
+#' @importFrom magrittr "%>%"
 #' @export
 magrittr::`%>%`
 
@@ -224,11 +224,11 @@ rxode2::.minfo
 #' @export
 rxode2::RxODE
 
-#' @importFrom rxode2 `ini<-`
+#' @importFrom rxode2 "ini<-"
 #' @export
 rxode2::`ini<-`
 
-#' @importFrom rxode2 `model<-`
+#' @importFrom rxode2 "model<-"
 #' @export
 rxode2::`model<-`
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,6 +141,33 @@
   ret
 } # nocov end
 
+#' Spell an imported name so `@importFrom` survives roxygen2's merged form
+#'
+#' roxygen2 (>= 8.1) collapses every `@importFrom <pkg>` block for a package
+#' into one multi-name `importFrom(<pkg>, a, b, c)` directive.  R's
+#' `parseNamespaceFile()` reads that directive by dropping the first two
+#' elements and calling `as.character()` on what is left -- which makes the
+#' first name the call head and everything after it an argument.  A
+#' backtick-quoted non-syntactic name deparses back to plain text in the head
+#' position but keeps its backticks everywhere else, so
+#' `importFrom(rxode2, .minfo, `ini<-`)` asks rxode2 for an object literally
+#' named "`ini<-`".  That is a hard error in `importIntoEnv()`, so the *entire*
+#' directive fails and none of the package's imports land -- which in turn
+#' hides the imported generics from roxygen2's own S3 detection.
+#'
+#' Double quotes deparse cleanly in every position, so use them instead.
+#'
+#' @param fun name as it appears in the `pkg::name` reexport
+#' @return `fun`, with any backtick quoting swapped for double quoting
+#' @noRd
+.importName <- function(fun) { # nocov start
+  if (grepl("^`.*`$", fun)) {
+    paste0("\"", substr(fun, 2L, nchar(fun) - 1L), "\"")
+  } else {
+    fun
+  }
+} # nocov end
+
 .genSoftReExport <- function(fun, alias=NULL) { # nocov start
   message("Writing soft reexport: ", fun)
   .newFun <- strsplit(fun, "::")[[1]]
@@ -152,7 +179,7 @@
     .aliasText <- paste0("#' @rdname ", .fun)
   }
   paste(
-    c(paste("#' @importFrom", .pkg, .fun),
+    c(paste("#' @importFrom", .pkg, .importName(.fun)),
       .aliasText,
       "#' @export",
       fun


### PR DESCRIPTION
## The symptom

Running `devtools::document()` with roxygen2 8.1.0 silently produces a broken `NAMESPACE`: all **117** `S3method(rxUiGet, <class>)` registrations come back as `export(rxUiGet.<class>)`. Those methods are then never registered, so S3 dispatch cannot find them.

## The actual cause: imports, not S3

roxygen2 8.1 collapses every `@importFrom <pkg>` block for a package into one multi-name directive:

```r
importFrom(rxode2,
  .minfo,
  `ini<-`,
  ...
)
```

R's `parseNamespaceFile()` reads that by dropping the first two elements and calling `as.character()` on what remains — which puts the first name in the call head and the rest in argument position. A backtick-quoted non-syntactic name deparses cleanly in the head position but **keeps its backticks everywhere else**:

```r
> e <- quote(importFrom(rxode2, `ini<-`, rxUiGet, `model<-`))
> as.character(e[-1L][-1L])
[1] "ini<-"     "rxUiGet"   "`model<-`"
```

So the directive asks rxode2 for an object literally named ``` `model<-` ```. `importIntoEnv()` treats a missing import as an **error**, not a warning, so the *entire* `importFrom(rxode2, ...)` directive fails and **not one of its 34 imports lands**.

`rxUiGet` is one of them. With the generic absent from the namespace, roxygen2's own `is_s3_generic()` check fails and it concludes `rxUiGet.nlmerEnv` is an ordinary function — hence `export()` instead of `S3method()`.

Under roxygen2 8.0 each `@importFrom` became its own single-name directive, so the head position always applied and the bug never surfaced.

## The fix

Double quotes deparse cleanly in **every** position:

```r
> as.character(quote(importFrom(rxode2, .minfo, "ini<-", "model<-", rxUiGet))[-1L][-1L])
[1] ".minfo"  "ini<-"   "model<-" "rxUiGet"
```

- `@importFrom` tags for ``` `ini<-` ```, ``` `model<-` ``` and ``` `%>%` ``` now use double quotes.
- `.genSoftReExport()` gains `.importName()`, so regenerating `R/reexports.R` stays correct.
- `NAMESPACE` regenerated; `Config/roxygen2/version` bumped to 8.1.0.

## Verification

- **`NAMESPACE` is semantically identical to main's** — parsed both with `base:::parseNamespaceFile()`: 449 directives each, zero differences either way. The only real change is 8.1's multi-line `importFrom` formatting.
- All **117** `rxUiGet` methods resolve via `getS3method()`; every rxode2 import is present in the namespace.
- `R CMD INSTALL` clean, `tools::codoc()` reports 0 mismatches, test suite `FAIL 0 | WARN 1 | SKIP 1 | PASS 404` (the warning and skip are pre-existing).

## Note on the remaining roxygen messages

roxygen2 8.1 also emits `S3 method 'nlmixr2Est.fmeMcmc' needs @export or @exportS3Method` for eight methods. Those are **false positives**: they are registered at run time by `rxode2::.s3register()` in `.onLoad()` on purpose, and adding `@export` would double-register them and harden a soft dependency. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)