### PR TITLE
poped: keep the if() guard on adaptive dosing calls; make dose/duration/interval optimizable (#131)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # babelmixr2 0.1.11.9000
 
+* The PopED model translation no longer drops the `if ()` condition that
+  guards an adaptive dosing call (`evid_()`, `bolus()`, `infuse()`,
+  `infuseDur()`, `reset()`, ...).  The branch pruner used to flatten the
+  model unconditionally, so a model like `if (t <= 0) infuseDur(DOSE,
+  TINF, cmt=1)` pushed a dose at *every* design point instead of once
+  (#131).  The pruner's capture protocol is now used and the guarded call
+  is restored after the branches are flattened.
+
+* Added two PopED examples showing how to make the dosing regimen itself
+  optimizable (#131):
+
+  - `inst/poped/ex.10.PKPD.HCV.dose-and-tinf.babelmixr2.R` keeps the dose
+    record and makes the amount and infusion duration design (`a`)
+    variables via `f(depot) <- DOSE` (with `amt=1`) and
+    `dur(depot) <- TINF` (with `rate=-2`).
+
+  - `inst/poped/ex.10.PKPD.HCV.adaptive-dosing.babelmixr2.R` drops the
+    dose records entirely and pushes the regimen from inside the model
+    with `infuseDur()`, which makes the dosing *interval* a design
+    variable as well.  This one needs rxode2 > 5.1.7 (rxode2#1214).
+
+  Both are optimized with `poped_optim(..., opt_a=TRUE)` and agree on the
+  reference design (OFV 88.27).
+
 * The NONMEM/Monolix fit cache is now written with `saveRDS()` as
   `<model>.rds` / `nlmixr.rds` instead of `qs2`, so `qs2` moved from
   `Imports` to `Suggests`.  Existing run directories keep working: a

--- a/R/poped.R
+++ b/R/poped.R
@@ -875,7 +875,19 @@ rxUiGet.popedRxmodelBase <- function(x, ...) {
   .mod <- .mod[.w]
   .errDf <- .iniDf[!is.na(.iniDf$err), ,drop=FALSE]
   # remove if/else so extra lhs statements are not hanging around
-  .mod <- str2lang(paste0("{", rxode2::.rxPrune(as.call(c(quote(`{`), .mod))), "}"))
+  #
+  # Adaptive dosing calls (`evid_()`, `bolus()`, `infuse()`, `infuseDur()`,
+  # ...) cannot be flattened this way; the pruner captures them (and the
+  # conditions they were nested under) when `..captureN`/`..capturedEvid`
+  # are present in the pruning environment.  Without this the enclosing
+  # `if ()` is dropped and the dose fires at every event time.
+  .pruneEnv <- new.env(parent=emptyenv())
+  .pruneEnv$.if <- NULL
+  .pruneEnv$.def1 <- NULL
+  .pruneEnv$..captureN <- 0L
+  .pruneEnv$..capturedEvid <- list()
+  .mod <- str2lang(paste0("{", rxode2::.rxPrune(as.call(c(quote(`{`), .mod)),
+                                                envir=.pruneEnv), "}"))
   .mod <- lapply(seq_along(.mod)[-1],
                  function(i) { .mod[[i]]})
   .mod <- lapply(seq_along(.mod),
@@ -896,6 +908,17 @@ rxUiGet.popedRxmodelBase <- function(x, ...) {
                    }
                    .replaceErrWithConst(.cur, .errDf)
                  })
+  # restore the adaptive dosing calls captured by the pruner; the
+  # `rxCaptureId#` variables hold the (flattened) condition they were
+  # nested under.
+  if (length(.pruneEnv$..capturedEvid) > 0L) {
+    .mod <- c(.mod,
+              lapply(.pruneEnv$..capturedEvid,
+                     function(cap) {
+                       str2lang(paste0("if (", cap$capVar, ") { ",
+                                       cap$original, " }"))
+                     }))
+  }
   .mod
 }
 attr(rxUiGet.popedRxmodelBase, "desc") <- "This gets the base rxode2 model for PopED"

--- a/inst/poped/ex.10.PKPD.HCV.adaptive-dosing.babelmixr2.R
+++ b/inst/poped/ex.10.PKPD.HCV.adaptive-dosing.babelmixr2.R
@@ -1,0 +1,130 @@
+## HCV example (Nyberg et al., Br. J. Clin. Pharm., 2014) where the whole
+## regimen -- dose amount, infusion duration *and* dosing interval -- is
+## registered from inside the model with rxode2's adaptive dosing
+## functions, and all three are PopED design ("a") variables.
+## See https://github.com/nlmixr2/babelmixr2/issues/131
+##
+## Compare with ex.10.PKPD.HCV.dose-and-tinf.babelmixr2.R, which gets the
+## amount and the duration out of a dose record with `f()`/`dur()`.  That
+## approach is simpler and needs nothing from the solver, but the dosing
+## *interval* stays baked into the event table.  Here the design dataset
+## carries no dose records at all: `infuseDur()` pushes them, so `ii` is
+## just another covariate and can be optimized too.
+##
+## Requires rxode2 > 5.1.7 (the pushed-dose timing fix, rxode2#1214).
+
+library(babelmixr2)
+library(PopED)
+
+f <- function() {
+  ini({
+    tp <- fix(100)
+    td <- fix(0.001)
+    te <- fix(1e-7)
+    ts <- fix(20000)
+
+    tKA <- log(0.8)
+    tKE <- log(0.15)
+    tVD <- log(100)
+    tEC50 <- log(0.12)
+    tn <- log(2)
+    tdelta <- log(0.2)
+    tc <- log(7)
+
+    eta.KA ~ 0.25
+    eta.KE ~ 0.25
+    eta.VD ~ 0.25
+    eta.EC50 ~ 0.25
+    eta.n ~ 0.25
+    eta.delta ~ 0.25
+    eta.c ~ 0.25
+
+    add.sd.pk <- sqrt(0.04) # nlmixr2 uses sd
+    add.sd.pd <- sqrt(0.04)
+  })
+  model({
+    p <- tp
+    d <- td
+    e <- te
+    s <- ts
+    KA <- exp(tKA + eta.KA)
+    KE <- exp(tKE + eta.KE)
+    VD <- exp(tVD + eta.VD)
+    EC50 <- exp(tEC50 + eta.EC50)
+    n <- exp(tn + eta.n)
+    delta <- exp(tdelta + eta.delta)
+    c <- exp(tc + eta.c)
+
+    ## The design variables have to be copied into model variables before
+    ## they are handed to infuseDur(); a covariate that appears *only* as
+    ## an adaptive dosing argument is not registered as a parameter and
+    ## the model will not compile (rxode2#1231).
+    amtI <- DOSE
+    durI <- TINF
+    iiI  <- TAU
+
+    d/dt(depot)   <- -KA*depot
+    d/dt(central) <-  KA*depot - KE*central
+    d/dt(TC) <- s - TC*(e*VP + d)              # target cells (TC)
+    d/dt(IC) <- e*TC*VP - delta*IC             # productively infected cells
+    d/dt(VP) <- p*(1 - (pow(central/VD, n)/(pow(central/VD, n) +
+                                              pow(EC50, n))))*IC - c*VP
+
+    TC(0) <- c*delta/(p*e)
+    IC(0) <- (s*e*p - d*c*delta)/(p*delta*e)
+    VP(0) <- (s*e*p - d*c*delta)/(c*delta*e)
+
+    ## four infusions of DOSE over TINF, every TAU
+    if (t <= 0) {
+      infuseDur(amtI, durI, cmt=depot, ii=iiI, addl=3)
+    }
+
+    conc <- central/VD
+    eff  <- log10(VP)
+    conc ~ add(add.sd.pk)
+    eff  ~ add(add.sd.pd)
+  })
+}
+
+## observation-only design: there are no dose records to write down
+tms <- c(0, 0.25, 0.5, 1, 2, 3, 4, 7, 10, 14, 21, 28)
+e1 <- as.data.frame(et(tms))
+e1$dvid <- 1
+e2 <- e1
+e2$dvid <- 2
+e <- rbind(e1, e2)
+
+babel.db <- nlmixr2(f, e, "poped",
+                    popedControl(groupsize=30,
+                                 a=list(c(DOSE=180, TINF=1, TAU=7)),
+                                 mina=c(DOSE=20,  TINF=0.1, TAU=1),
+                                 maxa=c(DOSE=600, TINF=12,  TAU=14)))
+
+plot_model_prediction(babel.db, facet_scales="free")
+
+evaluate_design(babel.db)$ofv
+#> [1] 88.27007
+## ...which is the same design as the `f()`/`dur()` version of this
+## example (88.26974); the two parameterizations agree.
+
+## the interval is now a design variable like any other
+for (ta in c(1, 2, 3, 5, 7, 10, 14)) {
+  .db <- babel.db
+  .db$design$a[1, "TAU"] <- ta
+  message(sprintf("TAU = %5.1f   ofv = %.4f", ta, evaluate_design(.db)$ofv))
+}
+#> TAU =   1.0   ofv = 91.0976
+#> TAU =   2.0   ofv = 90.6507
+#> TAU =   3.0   ofv = 90.2115
+#> TAU =   5.0   ofv = 89.4562
+#> TAU =   7.0   ofv = 88.2701
+#> TAU =  10.0   ofv = 89.1156
+#> TAU =  14.0   ofv = 88.8393
+
+r <- poped_optim(babel.db, opt_a=TRUE, opt_xt=FALSE, parallel=FALSE)
+#> Optimized Covariates:
+#> Group 1: 1 : 600 : 7.1429 : 1
+#>
+#> OFV = 100.785
+#
+# (a random search, so the exact optimum moves between runs)

--- a/inst/poped/ex.10.PKPD.HCV.dose-and-tinf.babelmixr2.R
+++ b/inst/poped/ex.10.PKPD.HCV.dose-and-tinf.babelmixr2.R
@@ -1,0 +1,132 @@
+## HCV example (Nyberg et al., Br. J. Clin. Pharm., 2014) with the dose
+## amount *and* the infusion duration treated as PopED design ("a")
+## variables.  See https://github.com/nlmixr2/babelmixr2/issues/131
+##
+## The trick is to keep the dose *record* in the design dataset, but to
+## make both of its interesting quantities model quantities:
+##
+##  - `amt=1`   in the data + `f(depot)   <- DOSE` in the model
+##      => the administered amount is the covariate `DOSE`
+##  - `rate=-2` in the data + `dur(depot) <- TINF` in the model
+##      => the infusion duration is the covariate `TINF`
+##
+## Because `DOSE` and `TINF` are ordinary covariates as far as
+## rxode2/babelmixr2 are concerned, PopED sees them as elements of `a`
+## and can optimize over them with `opt_a=TRUE`.
+##
+## The dosing *interval* is still fixed by the event table here.  See
+## ex.10.PKPD.HCV.adaptive-dosing.babelmixr2.R for the variant that
+## pushes the whole regimen from inside the model with `infuseDur()`,
+## which makes `ii` a design variable too.
+
+library(babelmixr2)
+library(PopED)
+
+f <- function() {
+  ini({
+    tp <- fix(100)
+    td <- fix(0.001)
+    te <- fix(1e-7)
+    ts <- fix(20000)
+
+    tKA <- log(0.8)
+    tKE <- log(0.15)
+    tVD <- log(100)
+    tEC50 <- log(0.12)
+    tn <- log(2)
+    tdelta <- log(0.2)
+    tc <- log(7)
+
+    eta.KA ~ 0.25
+    eta.KE ~ 0.25
+    eta.VD ~ 0.25
+    eta.EC50 ~ 0.25
+    eta.n ~ 0.25
+    eta.delta ~ 0.25
+    eta.c ~ 0.25
+
+    add.sd.pk <- sqrt(0.04) # nlmixr2 uses sd
+    add.sd.pd <- sqrt(0.04)
+  })
+  model({
+    p <- tp
+    d <- td
+    e <- te
+    s <- ts
+    KA <- exp(tKA + eta.KA)
+    KE <- exp(tKE + eta.KE)
+    VD <- exp(tVD + eta.VD)
+    EC50 <- exp(tEC50 + eta.EC50)
+    n <- exp(tn + eta.n)
+    delta <- exp(tdelta + eta.delta)
+    c <- exp(tc + eta.c)
+
+    d/dt(depot)   <- -KA*depot
+    d/dt(central) <-  KA*depot - KE*central
+    d/dt(TC) <- s - TC*(e*VP + d)              # target cells (TC)
+    d/dt(IC) <- e*TC*VP - delta*IC             # productively infected cells
+    d/dt(VP) <- p*(1 - (pow(central/VD, n)/(pow(central/VD, n) +
+                                              pow(EC50, n))))*IC - c*VP
+
+    ## the two design variables enter here
+    f(depot)   <- DOSE  # the dataset carries amt=1
+    dur(depot) <- TINF  # the dataset carries rate=-2
+
+    TC(0) <- c*delta/(p*e)
+    IC(0) <- (s*e*p - d*c*delta)/(p*delta*e)
+    VP(0) <- (s*e*p - d*c*delta)/(c*delta*e)
+
+    conc <- central/VD
+    eff  <- log10(VP)
+    conc ~ add(add.sd.pk)
+    eff  ~ add(add.sd.pd)
+  })
+}
+
+TAU <- 7
+tms <- c(0, 0.25, 0.5, 1, 2, 3, 4, 7, 10, 14, 21, 28)
+
+## note `amt=1` and `rate=-2`; the actual amount/duration come from the model
+e1 <- et(amt=1, rate=-2, ii=TAU, addl=3, cmt="depot") |>
+  et(tms) |>
+  as.data.frame()
+e1$dvid <- 1
+
+e2 <- e1[e1$evid == 0, ]
+e2$dvid <- 2
+
+e <- rbind(e1, e2)
+
+babel.db <- nlmixr2(f, e, "poped",
+                    popedControl(groupsize=30,
+                                 a=list(c(DOSE=180, TINF=1)),
+                                 mina=c(DOSE=20,  TINF=0.1),
+                                 maxa=c(DOSE=600, TINF=12)))
+
+plot_model_prediction(babel.db, facet_scales="free")
+
+evaluate_design(babel.db)
+#> $ofv
+#> [1] 88.26974
+
+## the criterion really does depend on the infusion duration
+for (ti in c(0.1, 0.5, 1, 2, 4, 8, 12)) {
+  .db <- babel.db
+  .db$design$a[1, "TINF"] <- ti
+  message(sprintf("TINF = %5.2f   ofv = %.4f", ti, evaluate_design(.db)$ofv))
+}
+
+## ...so it can be optimized over
+r <- poped_optim(babel.db, opt_a=TRUE, opt_xt=FALSE, parallel=FALSE)
+#> Optimized Covariates:
+#> Group 1: 1 : 446.115 : 0.456544
+#>
+#> OFV = 95.5746
+#
+# (the default algorithm is a random search, so the exact DOSE/TINF the
+# optimizer lands on varies from run to run; the point is that both are
+# now optimized instead of being fixed features of the event table)
+
+## Note: `cmt` in the design dataset must be given by *name*
+## (`cmt="depot"`); a bare compartment number is not translated in the
+## PopED path and silently produces a design with no dosing.


### PR DESCRIPTION
Closes #131 -- the infusion duration (and the dose, and the dosing interval)
can now be PopED optimization variables.

## The bug

`rxUiGet.popedRxmodelBase()` flattens `if`/`else` with `.rxPrune()` so that no
stray lhs statements are left hanging around.  It called it without the capture
environment, so adaptive dosing calls (`evid_()`, `bolus()`, `infuse()`,
`infuseDur()`, `reset()`, ...) fell through to the generic call branch and the
condition guarding them was silently dropped:

```r
if (t <= 0) infuseDur(amtI, durI, cmt=depot, ii=iiI, addl=3)
```

became a bare `infuseDur(amtI, durI, 1, iiI, 3, 0)` in the translated model, so
a dose was pushed at *every* design point rather than once.  In the internal
mtime model that runs straight through `maxExtra=1000`:

```
Error: evid_() pushed more than maxExtra=1000 events per individual
```

and in the observation-driven path it silently produced a nonsense profile
(one dose per sampling time, accumulating).

The fix uses the pruner's `..captureN`/`..capturedEvid` protocol -- the same
one `.rxLoadPrune()` uses -- and re-emits each captured call after the branches
are flattened.  The translated model now reads

```
rxCaptureId1 ~ (t <= 0)
...
if (rxCaptureId1) { infuseDur(amtI, durI, 1, iiI, 3, 0) }
```

## Two ways to make the regimen a design variable

`inst/poped/ex.10.PKPD.HCV.dose-and-tinf.babelmixr2.R` keeps the dose record
and moves its two interesting quantities into the model:

```r
et(amt=1, rate=-2, ii=TAU, addl=3, cmt="depot")   # data
f(depot)   <- DOSE                                # model
dur(depot) <- TINF
```

`DOSE`/`TINF` are then ordinary covariates, so PopED sees them in `a`.  This
needs nothing from the solver, but the interval stays baked into the event
table.

`inst/poped/ex.10.PKPD.HCV.adaptive-dosing.babelmixr2.R` drops the dose records
entirely and pushes the regimen from inside the model, which makes `ii` a
design variable as well:

```r
amtI <- DOSE
durI <- TINF
iiI  <- TAU
...
if (t <= 0) infuseDur(amtI, durI, cmt=depot, ii=iiI, addl=3)
```

This one needs rxode2 > 5.1.7 for the pushed-dose timing fix
(nlmixr2/rxode2#1214); before that the pushed dose landed one design point
late.

## Verification

Both parameterizations reproduce a fixed event-table design exactly, and agree
with each other:

| design | OFV |
| --- | --- |
| plain event table (1-cmt check) | 38.16939 |
| `f()`/`dur()` | 38.16939 |
| `infuseDur()` push | 38.16942 |
| HCV, `f()`/`dur()` | 88.26974 |
| HCV, `infuseDur()` push | 88.27007 |

The criterion really does depend on the infusion duration and the interval, so
there is something to optimize:

```
TINF =  0.10  ofv = 87.9878      TAU =  1.0  ofv = 91.0976
TINF =  2.00  ofv = 88.3049      TAU =  7.0  ofv = 88.2701
TINF = 12.00  ofv = 84.1059      TAU = 14.0  ofv = 88.8393
```

and `poped_optim(opt_a=TRUE)` moves all three (HCV, random search, so the exact
optimum moves between runs): DOSE 600, TINF 7.14 h, TAU 1 d, OFV 88.27 ->
100.79.

Both example scripts run end to end.  `test-poped.R` has the same 5 failures
before and after this change.

## Side notes from the investigation

* The `gradfg` NAs reported in #131 were an artifact of the manual call --
  `db$design$a[1,]` drops the dimnames the `fg` function reads, so
  `rxPopedA['TINF']` is `NA`.  With `drop=FALSE` the covariate rows are 0, as
  they should be.
* A parameter used *only* as an adaptive dosing argument is not registered and
  the model will not compile; hence the `amtI <- DOSE` shim in the second
  example.  Filed as nlmixr2/rxode2#1231.
* A numeric `cmt` in a PopED design dataset silently yields a design with no
  doses.  Filed as #201.
