### PR TITLE
fix(poped): honor a numeric cmt in a design dataset (#201)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # babelmixr2 0.1.11.9000
 
+* A PopED design dataset that gives `cmt` as a compartment *number*
+  (`et(amt=180, cmt=1)`) now doses the right compartment.  `et()` keeps
+  `cmt` as a character column, so `rxode2::etTrans()` read `"1"` as a
+  compartment *name*, found no match and quietly moved the dose to an
+  extra compartment; the design built without a warning but every
+  prediction was zero and the FIM was degenerate (#201).  A dosing record
+  that still cannot be matched to a model compartment is now an error
+  instead of a silently empty design.
+
 * The PopED model translation no longer drops the `if ()` condition that
   guards an adaptive dosing call (`evid_()`, `bolus()`, `infuse()`,
   `infuseDur()`, `reset()`, ...).  The branch pruner used to flatten the

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,11 @@
   `cmt` as a character column, so `rxode2::etTrans()` read `"1"` as a
   compartment *name*, found no match and quietly moved the dose to an
   extra compartment; the design built without a warning but every
-  prediction was zero and the FIM was degenerate (#201).  A dosing record
-  that still cannot be matched to a model compartment is now an error
-  instead of a silently empty design.
+  prediction was zero and the FIM was degenerate (#201).  This also works
+  when the column mixes names and numbers, which is what a multiple
+  endpoint design looks like when it names the endpoint on its
+  observation records.  A dosing record that still cannot be matched to a
+  model compartment is now an error instead of a silently empty design.
 
 * The PopED model translation no longer drops the `if ()` condition that
   guards an adaptive dosing call (`evid_()`, `bolus()`, `infuse()`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@
   observation records.  A dosing record that still cannot be matched to a
   model compartment is now an error instead of a silently empty design.
 
+* A multiple endpoint PopED design can now name its endpoints with `cmt`
+  (`cmt="cp"`, `cmt="eff"`) instead of `dvid`.  The `cmt` fallback was
+  already written but unreachable: a dataset without a `dvid` column
+  stopped with `attempt to select less than one element in get1index`
+  before it was tried.
+
 * The PopED model translation no longer drops the `if ()` condition that
   guards an adaptive dosing call (`evid_()`, `bolus()`, `infuse()`,
   `infuseDur()`, `reset()`, ...).  The branch pruner used to flatten the

--- a/R/poped.R
+++ b/R/poped.R
@@ -2059,6 +2059,83 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   ret
 }
 
+#' Translate a numeric compartment given as a string back to a number
+#'
+#' `et()` keeps `cmt` as a character column, so a design dataset built
+#' with a compartment *number* (`et(amt=180, cmt=1)`) arrives here with
+#' the string `"1"`.  `rxode2::etTrans()` reads a character `cmt` as a
+#' compartment *name*; `"1"` matches no state, so the record is assigned
+#' to an extra compartment and the dose is silently dropped from the
+#' design (nlmixr2/babelmixr2#201).  `rxode2` converts these back to
+#' integers before solving (`.etFixCmtForSolve()`); do the same here.
+#'
+#' @param data babelmixr2 design data
+#' @return design data where a fully numeric character `cmt` column has
+#'   been converted to an integer column; anything else is returned
+#'   unchanged
+#' @noRd
+#' @author Matthew L. Fidler
+.popedFixDataCmt <- function(data) {
+  .nd <- tolower(names(data))
+  .wcmt <- which(.nd == "cmt")
+  if (length(.wcmt) != 1L) return(data)
+  .cmt <- data[[.wcmt]]
+  if (is.factor(.cmt)) .cmt <- as.character(.cmt)
+  if (!is.character(.cmt)) return(data)
+  .isNa <- is.na(.cmt)
+  # "(default)"/"(obs)" are the rxode2 sentinels for "no compartment given"
+  .isSentinel <- !.isNa & (.cmt == "(default)" | .cmt == "(obs)")
+  .num <- suppressWarnings(as.integer(.cmt))
+  .isNum <- !.isNa & !.isSentinel & !is.na(.num)
+  if (!all(.isNa | .isSentinel | .isNum)) return(data)
+  .int <- integer(length(.cmt))
+  .int[.isNa] <- NA_integer_
+  .int[.isSentinel] <- 1L
+  .int[.isNum] <- .num[.isNum]
+  data[[.wcmt]] <- .int
+  data
+}
+
+#' Make sure every dosing record can be matched to a model compartment
+#'
+#' A dose that cannot be matched is dropped by `rxode2::etTrans()`, which
+#' gives a design with no doses at all; every prediction is then zero and
+#' the FIM is degenerate, which reads as "your design is bad" instead of
+#' "your dose was thrown away" (nlmixr2/babelmixr2#201).
+#'
+#' @param ui rxode2 ui function
+#' @param data babelmixr2 design data (after `.popedFixDataCmt()`)
+#' @return nothing, called for the error it throws
+#' @noRd
+#' @author Matthew L. Fidler
+.popedAssertDoseCmt <- function(ui, data) {
+  .nd <- tolower(names(data))
+  .wcmt <- which(.nd == "cmt")
+  if (length(.wcmt) != 1L) return(invisible())
+  .wevid <- which(.nd == "evid")
+  # without evid every record is a design point (see .popedDataToDesignSpace())
+  if (length(.wevid) != 1L) return(invisible())
+  .cmt <- data[[.wcmt]][which(data[[.wevid]] != 0)]
+  if (length(.cmt) == 0L) return(invisible())
+  .state <- rxode2::rxModelVars(ui)$state
+  if (is.factor(.cmt)) .cmt <- as.character(.cmt)
+  if (is.character(.cmt)) {
+    # a leading "-" turns the compartment off (evid=2)
+    .bad <- .cmt[!is.na(.cmt) &
+                   !(sub("^-", "", .cmt) %in% c(.state, "(default)", "(obs)"))]
+  } else {
+    .n <- abs(as.integer(.cmt))
+    .bad <- .cmt[!is.na(.n) & (.n < 1L | .n > length(.state))]
+  }
+  .bad <- unique(.bad)
+  if (length(.bad) == 0L) return(invisible())
+  stop("the dosing records of the design dataset use compartment(s) not in the model: ",
+       paste0("'", .bad, "'", collapse=", "),
+       "\nthe model compartments are: ",
+       paste0("'", .state, "'", collapse=", "),
+       call.=FALSE)
+}
+
 #' Setup the poped database
 #'
 #' @param ui rxode2 ui function
@@ -2072,6 +2149,7 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   #
   # Data needs to match what PopED prefers, so order by id, dvid then time, not the typical ordering.  This only needs to be done in cases where there is a dvid.
   #
+  data <- .popedFixDataCmt(data)
   .nd <- tolower(names(data))
   .wdvid <- which(.nd == "dvid")
   if (length(.wdvid) == 1L) {
@@ -2091,6 +2169,7 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   # - model -- rxode2 model (setup with .popedDataToDesignSpace)
   # - data -- rxode2 data (setup with .popedDataToDesignSpace)
   .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(ui))
+  .popedAssertDoseCmt(.ui, data)
   # Set control options to be used within functions
   .ctl <- control
   class(.ctl) <- NULL

--- a/R/poped.R
+++ b/R/poped.R
@@ -2069,13 +2069,19 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
 #' design (nlmixr2/babelmixr2#201).  `rxode2` converts these back to
 #' integers before solving (`.etFixCmtForSolve()`); do the same here.
 #'
+#' A multiple endpoint design names the endpoint on its observation
+#' records (`cmt="cp"`, `cmt="eff"`), so the column can hold both names
+#' and numbers.  Such a column has to stay character; the numbers are
+#' replaced by the compartment they refer to instead.
+#'
+#' @param ui rxode2 ui function
 #' @param data babelmixr2 design data
-#' @return design data where a fully numeric character `cmt` column has
-#'   been converted to an integer column; anything else is returned
+#' @return design data where the numeric compartments of a character
+#'   `cmt` column have been translated; anything else is returned
 #'   unchanged
 #' @noRd
 #' @author Matthew L. Fidler
-.popedFixDataCmt <- function(data) {
+.popedFixDataCmt <- function(ui, data) {
   .nd <- tolower(names(data))
   .wcmt <- which(.nd == "cmt")
   if (length(.wcmt) != 1L) return(data)
@@ -2087,12 +2093,23 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   .isSentinel <- !.isNa & (.cmt == "(default)" | .cmt == "(obs)")
   .num <- suppressWarnings(as.integer(.cmt))
   .isNum <- !.isNa & !.isSentinel & !is.na(.num)
-  if (!all(.isNa | .isSentinel | .isNum)) return(data)
-  .int <- integer(length(.cmt))
-  .int[.isNa] <- NA_integer_
-  .int[.isSentinel] <- 1L
-  .int[.isNum] <- .num[.isNum]
-  data[[.wcmt]] <- .int
+  if (all(.isNa | .isSentinel | .isNum)) {
+    # no compartment names at all, so the column can become integer
+    .int <- integer(length(.cmt))
+    .int[.isNa] <- NA_integer_
+    .int[.isSentinel] <- 1L
+    .int[.isNum] <- .num[.isNum]
+    data[[.wcmt]] <- .int
+    return(data)
+  }
+  .state <- rxode2::rxModelVars(ui)$state
+  # a leading "-" turns the compartment off (evid=2)
+  .w <- which(.isNum & abs(.num) >= 1L & abs(.num) <= length(.state))
+  .cmt[.w] <- ifelse(.num[.w] < 0L,
+                     paste0("-", .state[abs(.num[.w])]),
+                     .state[.num[.w]])
+  # anything left over is out of range; .popedAssertDoseCmt() complains
+  data[[.wcmt]] <- .cmt
   data
 }
 
@@ -2149,7 +2166,6 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   #
   # Data needs to match what PopED prefers, so order by id, dvid then time, not the typical ordering.  This only needs to be done in cases where there is a dvid.
   #
-  data <- .popedFixDataCmt(data)
   .nd <- tolower(names(data))
   .wdvid <- which(.nd == "dvid")
   if (length(.wdvid) == 1L) {
@@ -2169,6 +2185,7 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   # - model -- rxode2 model (setup with .popedDataToDesignSpace)
   # - data -- rxode2 data (setup with .popedDataToDesignSpace)
   .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(ui))
+  data <- .popedFixDataCmt(.ui, data)
   .popedAssertDoseCmt(.ui, data)
   # Set control options to be used within functions
   .ctl <- control

--- a/R/poped.R
+++ b/R/poped.R
@@ -1285,10 +1285,16 @@ attr(rxUiGet.popedNotfixedSigma, "rstudio") <- 0L
                                                       .data[[.wevid]] == 0, ]
                                      .time <- .data[[.wtime]]
                                      .env$mt <- max(c(.time, .env$mt))
-                                     .wd <- which(.data[[.wdvid]] == i)
-                                     if (length(.wd) == 0) {
-                                       .wd <- which(.data[[.wdvid]] ==
-                                                      ui$predDf$cond[i])
+                                     # without a dvid column the cmt
+                                     # fallback below is the only way to
+                                     # match the design points
+                                     .wd <- integer(0)
+                                     if (length(.wdvid) == 1L) {
+                                       .wd <- which(.data[[.wdvid]] == i)
+                                       if (length(.wd) == 0) {
+                                         .wd <- which(.data[[.wdvid]] ==
+                                                        ui$predDf$cond[i])
+                                       }
                                      }
                                      if (length(.wd) > 0) {
                                        .time <- .time[.wd]

--- a/R/poped.R
+++ b/R/poped.R
@@ -2105,9 +2105,10 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   .state <- rxode2::rxModelVars(ui)$state
   # a leading "-" turns the compartment off (evid=2)
   .w <- which(.isNum & abs(.num) >= 1L & abs(.num) <= length(.state))
+  # ifelse() evaluates both branches, so both have to index with abs()
   .cmt[.w] <- ifelse(.num[.w] < 0L,
                      paste0("-", .state[abs(.num[.w])]),
-                     .state[.num[.w]])
+                     .state[abs(.num[.w])])
   # anything left over is out of range; .popedAssertDoseCmt() complains
   data[[.wcmt]] <- .cmt
   data
@@ -2132,7 +2133,8 @@ attr(rxUiGet.popedOptsw, "rstudio") <- 1
   .wevid <- which(.nd == "evid")
   # without evid every record is a design point (see .popedDataToDesignSpace())
   if (length(.wevid) != 1L) return(invisible())
-  .cmt <- data[[.wcmt]][which(data[[.wevid]] != 0)]
+  # evid=3 resets the system; rxode2 ignores its compartment
+  .cmt <- data[[.wcmt]][which(data[[.wevid]] != 0 & data[[.wevid]] != 3)]
   if (length(.cmt) == 0L) return(invisible())
   .state <- rxode2::rxModelVars(ui)$state
   if (is.factor(.cmt)) .cmt <- as.character(.cmt)

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -894,6 +894,20 @@ if (requireNamespace("PopED", quietly=TRUE) &&
                  model_prediction(nlmixr2(f, evName2, "poped",
                                           popedControl(groupsize=20)))$PRED)
 
+    # a column that mixes compartment names and numbers still has to
+    # translate the numbers
+    evMix <- et(amt=180, cmt="depot") %>%
+      et(amt=50, time=2, cmt=2) %>%
+      et(tms)
+    evMixName <- et(amt=180, cmt="depot") %>%
+      et(amt=50, time=2, cmt="central") %>%
+      et(tms)
+
+    expect_equal(model_prediction(nlmixr2(f, evMix, "poped",
+                                          popedControl(groupsize=20)))$PRED,
+                 model_prediction(nlmixr2(f, evMixName, "poped",
+                                          popedControl(groupsize=20)))$PRED)
+
     # a dose that cannot be matched to a compartment is an error instead
     # of a silently empty design
     expect_error(nlmixr2(f, et(amt=180, cmt=5) %>% et(tms), "poped",
@@ -903,6 +917,57 @@ if (requireNamespace("PopED", quietly=TRUE) &&
     expect_error(nlmixr2(f, et(amt=180, cmt="matt") %>% et(tms), "poped",
                          popedControl(groupsize=20)),
                  "not in the model")
+
+  })
+
+  test_that("a numeric cmt works for a multiple endpoint design (#201)", {
+
+    library(PopED)
+
+    f <- function() {
+      ini({
+        tKA <- log(0.8)
+        tCL <- log(15)
+        tV <- log(100)
+        tE0 <- log(10)
+        eta.KA ~ 0.25
+        prop.sd <- sqrt(0.04)
+        eff.sd <- 1
+      })
+      model({
+        KA <- exp(tKA + eta.KA)
+        CL <- exp(tCL)
+        V <- exp(tV)
+        E0 <- exp(tE0)
+        d/dt(depot) <- -KA*depot
+        d/dt(central) <- KA*depot - (CL/V)*central
+        cp <- central/V
+        eff <- E0 - cp
+        cp ~ prop(prop.sd)
+        eff ~ add(eff.sd)
+      })
+    }
+
+    tms <- c(0.25, 1, 2, 4)
+
+    # the design points name the endpoint with dvid, the dose names the
+    # compartment
+    .mkData <- function(doseCmt) {
+      .d <- as.data.frame(et(amt=180, cmt=doseCmt) %>% et(tms))
+      .d$id <- 1
+      .obs1 <- .d[.d$evid == 0, ]
+      .obs1$dvid <- 1
+      .obs2 <- .obs1
+      .obs2$dvid <- 2
+      .dose <- .d[.d$evid != 0, , drop=FALSE]
+      .dose$dvid <- 1
+      rbind(.dose, .obs1, .obs2)
+    }
+
+    expect_equal(model_prediction(nlmixr2(f, .mkData(1), "poped",
+                                          popedControl(groupsize=20)))$PRED,
+                 model_prediction(nlmixr2(f, .mkData("depot"), "poped",
+                                          popedControl(groupsize=20)))$PRED)
 
   })
 

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -920,6 +920,66 @@ if (requireNamespace("PopED", quietly=TRUE) &&
 
   })
 
+  test_that("cmt normalization edge cases (#201)", {
+
+    f <- function() {
+      ini({
+        tKA <- log(0.8)
+        tCL <- log(15)
+        tV <- log(100)
+        eta.KA ~ 0.25
+        prop.sd <- sqrt(0.04)
+      })
+      model({
+        KA <- exp(tKA + eta.KA)
+        CL <- exp(tCL)
+        V <- exp(tV)
+        d/dt(depot) <- -KA*depot
+        d/dt(central) <- KA*depot - (CL/V)*central
+        cp <- central/V
+        cp ~ prop(prop.sd)
+      })
+    }
+
+    p <- f()
+
+    # a column of numbers only becomes integer, the way rxode2 does it
+    # before solving
+    expect_equal(.popedFixDataCmt(p, data.frame(cmt=c("1", NA, "(default)",
+                                                      "(obs)", "-2")))$cmt,
+                 c(1L, NA_integer_, 1L, 1L, -2L))
+
+    # a column that mixes names and numbers stays character; a negative
+    # compartment (evid=2 turns it off) keeps its sign
+    expect_equal(.popedFixDataCmt(p, data.frame(cmt=c("depot", "2", "-2",
+                                                      NA, "5")))$cmt,
+                 c("depot", "central", "-central", NA, "5"))
+
+    # a factor is normalized too
+    expect_equal(.popedFixDataCmt(p, data.frame(cmt=factor(c("depot", "2"))))$cmt,
+                 c("depot", "central"))
+
+    # nothing to do without a cmt column
+    expect_equal(.popedFixDataCmt(p, data.frame(time=1:2))$time, 1:2)
+
+    # a reset (evid=3) ignores its compartment in rxode2, so it cannot be
+    # an error here
+    expect_error(.popedAssertDoseCmt(p, data.frame(evid=c(1, 3),
+                                                   cmt=c(1L, 99L))),
+                 NA)
+
+    expect_error(.popedAssertDoseCmt(p, data.frame(evid=c(1, 1),
+                                                   cmt=c(1L, 99L))),
+                 "not in the model")
+
+    # observation records are not checked; a multiple endpoint design
+    # names the endpoint there
+    expect_error(.popedAssertDoseCmt(p, data.frame(evid=c(1, 0),
+                                                   cmt=c("depot", "cp"))),
+                 NA)
+
+  })
+
   test_that("a numeric cmt works for a multiple endpoint design (#201)", {
 
     library(PopED)

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -1029,6 +1029,27 @@ if (requireNamespace("PopED", quietly=TRUE) &&
                  model_prediction(nlmixr2(f, .mkData("depot"), "poped",
                                           popedControl(groupsize=20)))$PRED)
 
+    # the design points can name their endpoint with cmt instead of dvid;
+    # the dose can still use a compartment number, which makes the cmt
+    # column a mix of names and numbers
+    .mkCmtData <- function(doseCmt) {
+      .d <- as.data.frame(et(amt=180, cmt=doseCmt) %>%
+                            et(time=tms, cmt="cp") %>%
+                            et(time=tms, cmt="eff"))
+      .d$id <- 1
+      .d
+    }
+
+    expect_equal(model_prediction(nlmixr2(f, .mkCmtData(1), "poped",
+                                          popedControl(groupsize=20)))$PRED,
+                 model_prediction(nlmixr2(f, .mkCmtData("depot"), "poped",
+                                          popedControl(groupsize=20)))$PRED)
+
+    expect_equal(model_prediction(nlmixr2(f, .mkCmtData(1), "poped",
+                                          popedControl(groupsize=20)))$PRED,
+                 model_prediction(nlmixr2(f, .mkData(1), "poped",
+                                          popedControl(groupsize=20)))$PRED)
+
   })
 
 }

--- a/tests/testthat/test-poped.R
+++ b/tests/testthat/test-poped.R
@@ -846,4 +846,64 @@ if (requireNamespace("PopED", quietly=TRUE) &&
 
   })
 
+  test_that("a numeric cmt gives the same design as a named cmt (#201)", {
+
+    library(PopED)
+
+    f <- function() {
+      ini({
+        tKA <- log(0.8)
+        tCL <- log(15)
+        tV <- log(100)
+        eta.KA ~ 0.25
+        eta.CL ~ 0.25
+        eta.V ~ 0.25
+        prop.sd <- sqrt(0.04)
+      })
+      model({
+        KA <- exp(tKA + eta.KA)
+        CL <- exp(tCL + eta.CL)
+        V <- exp(tV + eta.V)
+        d/dt(depot) <- -KA*depot
+        d/dt(central) <- KA*depot - (CL/V)*central
+        cp <- central/V
+        cp ~ prop(prop.sd)
+      })
+    }
+
+    tms <- c(0.25, 0.5, 1, 2, 3, 6, 8, 12, 24)
+
+    evName <- et(amt=180, rate=180, ii=24, addl=3, cmt="depot") %>% et(tms)
+    evNum <- et(amt=180, rate=180, ii=24, addl=3, cmt=1) %>% et(tms)
+
+    predName <- model_prediction(nlmixr2(f, evName, "poped",
+                                         popedControl(groupsize=20)))$PRED
+    predNum <- model_prediction(nlmixr2(f, evNum, "poped",
+                                        popedControl(groupsize=20)))$PRED
+
+    # the dose has to actually reach the system
+    expect_true(all(predName > 0))
+    expect_equal(predNum, predName)
+
+    # dosing into the second compartment is also honored
+    evNum2 <- et(amt=180, rate=180, ii=24, addl=3, cmt=2) %>% et(tms)
+    evName2 <- et(amt=180, rate=180, ii=24, addl=3, cmt="central") %>% et(tms)
+
+    expect_equal(model_prediction(nlmixr2(f, evNum2, "poped",
+                                          popedControl(groupsize=20)))$PRED,
+                 model_prediction(nlmixr2(f, evName2, "poped",
+                                          popedControl(groupsize=20)))$PRED)
+
+    # a dose that cannot be matched to a compartment is an error instead
+    # of a silently empty design
+    expect_error(nlmixr2(f, et(amt=180, cmt=5) %>% et(tms), "poped",
+                         popedControl(groupsize=20)),
+                 "not in the model")
+
+    expect_error(nlmixr2(f, et(amt=180, cmt="matt") %>% et(tms), "poped",
+                         popedControl(groupsize=20)),
+                 "not in the model")
+
+  })
+
 }


### PR DESCRIPTION
Fixes #201.

## The bug

`et()` keeps `cmt` as a **character** column, so a design dataset built with a
compartment *number* — `et(amt=180, cmt=1)` — reached `rxode2::etTrans()` as the
string `"1"`.  `etTrans()` reads a character `cmt` as a compartment *name*,
found no match, and assigned the record to an extra compartment.  The dose was
dropped without a warning: the design built fine, every prediction was zero and
the FIM was degenerate, which reads as "your design is bad" rather than "your
dose was thrown away".

`rxSolve()` does not have this problem because `rxode2` converts a numeric-string
`cmt` back to an integer before solving (`.etFixCmtForSolve()`).

## The fix

`.popedFixDataCmt()` does the same normalization on the PopED design data:

* a `cmt` column holding only numbers (and `NA` / the `(default)`/`(obs)`
  sentinels) becomes integer, exactly as `rxode2` does when solving;
* a column that *mixes* names and numbers has to stay character — that is what a
  multiple endpoint design looks like when it names the endpoint on its
  observation records — so the numbers are replaced by the compartment they refer
  to (`2` -> `"central"`, `-2` -> `"-central"`);
* a factor column is normalized to character on the way through.

`.popedAssertDoseCmt()` then errors when a dosing record still cannot be matched
to a model compartment, instead of building a silently empty design.  Reset
records (`evid=3`) are skipped, since `rxode2` ignores their compartment.

## Also fixed

`.popedDataToDesignSpace()` has a `cmt` fallback for matching design points to
endpoints when there is no `dvid` column, but it was unreachable: the `dvid`
lookup ran unguarded, so such a dataset indexed the data frame with `integer(0)`
and stopped with `attempt to select less than one element in get1index`.  A
multiple endpoint design can now name its endpoints with `cmt="cp"` /
`cmt="eff"`.

## Verification

The reproducer from the issue now gives the same predictions for both event
tables:

```
cmt="depot" : 0.0416 0.1542 0.5323 1.0855 1.2162 0.9438 0.7143 0.3949 0.0653
cmt=1       : 0.0416 0.1542 0.5323 1.0855 1.2162 0.9438 0.7143 0.3949 0.0653
```

`tests/testthat/test-poped.R` gains coverage for the single- and
multiple-endpoint designs, the mixed name/number column, the normalization edge
cases (factor, sentinels, negative and out-of-range compartments, reset records)
and the new error.  The suite is at `FAIL 1 | PASS 49`; the one failure
(`poped intro`, a stochastic FIM comparison at line 302) is present on `main`
before this branch.

This change was reviewed with Antigravity (Gemini) over four passes; the
mixed-sign `ifelse()` crash, the `evid=3` reset regression and the unguarded
`dvid` lookup all came out of that review and are fixed here.