### PR TITLE
build: track header dependencies so an object cannot go stale

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^vignettes/articles$
 ^_pkgdown\.yml$
 ^\.vexp$
+^src/.*[.]d$

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ inst/doc
 /src/Makevars.win
 docs
 /.vexp/
+/src/*.d

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # babelmixr2 0.1.11.9000
 
+## Internal
+
+- The build now tracks header dependencies.  R's rules rebuild an object only
+  when its own source is newer, so an incremental build silently kept objects
+  that had been compiled against an earlier version of a header they include.
+  That reaches across packages: a `LinkingTo` package's headers are just
+  another include path, so a struct whose layout changes there leaves objects
+  here compiled to the old layout and the resulting shared library mixes both
+  -- a corrupt binary rather than a compile error.  `src/Makevars*` now
+  compiles with `-MMD -MP` and reads back the generated `.d` files.
+
 * The PopED model translation no longer drops the `if ()` condition that
   guards an adaptive dosing call (`evid_()`, `bolus()`, `infuse()`,
   `infuseDur()`, `reset()`, ...).  The branch pruner used to flatten the

--- a/cleanup
+++ b/cleanup
@@ -1,2 +1,3 @@
 #! /bin/sh
 rm -f src/Makevars
+rm -f src/*.d

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,2 +1,3 @@
 #! /bin/sh
 rm -f src/Makevars.win
+rm -f src/*.d

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -5,6 +5,28 @@ EG=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppEig
 RXAPI=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(length(rxode2::.rxode2ptrs()))'`
 
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
-PKG_CXXFLAGS = -Id -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -DRXAPI=$(RXAPI)
+PKG_CXXFLAGS = -Id -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -DRXAPI=$(RXAPI) -MMD -MP
+PKG_CFLAGS = -MMD -MP
 SHLIB_LDFLAGS = $(SHLIB_CXXLDFLAGS)
 SHLIB_LD = $(SHLIB_CXXLD)
+
+################################################################################
+## Header dependency tracking.
+##
+## R's build rules make an object depend on its own source only, so an object
+## goes stale -- silently -- when a header it includes changes and the source
+## does not.  That reaches across packages too: a LinkingTo package's headers
+## are just another include path, so a struct that changes there leaves the
+## objects here compiled to the previous layout.
+##
+## -MMD (in PKG_CFLAGS/PKG_CXXFLAGS above) records each object's headers in a
+## .d file beside it; -MP emits a phony target per header so one that is later
+## renamed or deleted does not break the build.  The .d files the previous
+## build wrote are read back below.
+##
+## Makevars is read before shlib.mk defines "all", so without .DEFAULT_GOAL the
+## first target of the first .d file becomes make's default goal and the shared
+## library is never linked.
+################################################################################
+.DEFAULT_GOAL := all
+-include $(wildcard *.d)


### PR DESCRIPTION
R's build rules make an object depend on its own source alone, so make reuses an object whenever only a header it includes has changed.  Nothing warns; the object simply keeps whatever layout that header had when it was last compiled.

That crosses package boundaries.  A LinkingTo package's headers are just another include path, so when a struct there gains or reorders a field, the objects here that were compiled against the previous layout are kept and linked alongside freshly compiled ones.  The result is a shared library whose halves disagree about member offsets -- a corrupt binary rather than a compile error, surfacing as a segfault far from the cause.

Compile with -MMD -MP so each object records its headers in a .d file beside it, and read those files back.  -MP emits a phony target per header so renaming or deleting one does not break the next build.

.DEFAULT_GOAL := all is required, not cosmetic: Makevars is read before shlib.mk defines "all", so without it the first target of the first included .d file becomes make's default goal and the shared library is never linked even though its objects rebuild.